### PR TITLE
[11-241] not-found 페이지 구현 및 테스트 코드 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "lint:check": "eslint . --cache --cache-location ./node_modules/.cache/eslint/.eslintcache",
     "type-check": "tsc --noEmit",
     "format": "prettier --write \"src/**/*.{js,jsx,ts,tsx,json}\" --cache --ignore-path .gitignore",
-    "format:check": "prettier --check \"src/**/*.{js,jsx,ts,tsx,json}\" --cache --ignore-path .gitignore"
+    "format:check": "prettier --check \"src/**/*.{js,jsx,ts,tsx,json}\" --cache --ignore-path .gitignore",
+    "test:playwright": "playwright test"
   },
   "dependencies": {
     "@tanstack/react-query": "^5.96.2",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from '@playwright/test'
+
+export default defineConfig({
+  webServer: {
+    command: 'bun dev',
+    url: 'http://localhost:3000',
+    timeout: 120 * 1000,
+    reuseExistingServer: !process.env.CI,
+  },
+  use: {
+    baseURL: 'http://localhost:3000/',
+  },
+})

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,8 +1,19 @@
 'use client'
 
 import Link from 'next/link'
+import { useRouter } from 'next/navigation'
 
 export default function NotFound() {
+  const router = useRouter()
+
+  const handleGoBack = () => {
+    if (window.history.length > 1) {
+      router.back()
+    } else {
+      router.push('/')
+    }
+  }
+
   return (
     <div
       className={
@@ -36,7 +47,7 @@ export default function NotFound() {
           </Link>
 
           <button
-            onClick={() => globalThis.history.back()}
+            onClick={handleGoBack}
             className={
               'cursor-pointer px-6 py-3 bg-slate-200 text-slate-800 font-medium rounded-lg transition-all duration-600 transform hover:scale-101 hover:bg-slate-300'
             }

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,50 @@
+'use client'
+
+import Link from 'next/link'
+
+export default function NotFound() {
+  return (
+    <div
+      className={
+        'flex-1 flex flex-col items-center justify-center bg-linear-to-r from-slate-50 to-slate-100'
+      }
+    >
+      <div
+        className={
+          'max-w-md mx-auto rounded-xl shadow-lg p-8 bg-white text-center transform transition-all'
+        }
+      >
+        <h1 className="text-2xl font-bold mb-4 text-slate-800 dark:text-slate-100">
+          <span role="presentation" className="flex justify-center mb-6">
+            ❌
+          </span>
+          페이지를 찾을 수 없습니다.
+        </h1>
+
+        <p className="text-slate-600 dark:text-slate-300 mb-8 text-md">
+          요청하신 페이지가 존재하지 않거나 이동되었을 수 있습니다.
+        </p>
+
+        <div className="flex flex-col sm:flex-row gap-4 justify-center">
+          <Link
+            href="/"
+            className={
+              'cursor-pointer px-6 py-3 bg-blue-600 text-white font-medium rounded-lg transition-all duration-600 transform hover:scale-101 hover:bg-blue-700'
+            }
+          >
+            홈으로 돌아가기
+          </Link>
+
+          <button
+            onClick={() => globalThis.history.back()}
+            className={
+              'cursor-pointer px-6 py-3 bg-slate-200 text-slate-800 font-medium rounded-lg transition-all duration-600 transform hover:scale-101 hover:bg-slate-300'
+            }
+          >
+            이전 페이지로 돌아가기
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/tests/not-found.spec.ts
+++ b/tests/not-found.spec.ts
@@ -1,0 +1,17 @@
+// tests/not-found.spec.ts
+
+import { test, expect } from '@playwright/test'
+
+test('404 페이지 렌더링', async ({ page }) => {
+  await page.goto('/없는페이지')
+
+  await expect(page.getByText('페이지를 찾을 수 없습니다.')).toBeVisible()
+})
+
+test('홈으로 돌아가기', async ({ page }) => {
+  await page.goto('/없는페이지')
+
+  await page.getByRole('link', { name: '홈으로 돌아가기' }).click()
+
+  await expect(page).toHaveURL('/')
+})


### PR DESCRIPTION
## ✨ 작업 내용

> not-found 페이지 데모 생성 및 playwright 설정, 테스트 코드 작성 했습니다.

## 🧩 백그라운드

> 사용자가 잘못된 주소로 접속했을 때 사용자 경험(UX)을 저해하지 않고 사이트 내 다른 페이지로 유도하여 이탈을 막고 SEO(검색 엔진 최적화)에 긍정적 영향을 주기 위해 필요한 페이지라서 작업했습니다.

## 📸 스크린샷(선택)

> 스크린샷이 필요한 작업이면 스크린샷을 첨부해주세요

## ✅ 테스트

- [x] 정상 동작 확인

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

> 참고할 사항이 있다면 적어주세요
