### PR TITLE
[11-111] 비밀번호 재설정 페이지 퍼블리싱

### DIFF
--- a/src/app/(auth)/reset-password/page.tsx
+++ b/src/app/(auth)/reset-password/page.tsx
@@ -1,65 +1,43 @@
 'use client'
 
 import { useState } from 'react'
+import Button from '@/components/common/button/Button'
 import EmailSection from '@/components/auth/signup/EmailSection'
-import PasswordField from '@/components/common/input/PasswordField'
-
-const PASSWORD_REGEX =
-  /^(?=.*[a-zA-Z])(?=.*\d)(?=.*[!@#$%^&*()_+\-=[\]{};':"\\|,.<>/?]).{8,}$/
-
-function isValidNewPassword(pw: string) {
-  return PASSWORD_REGEX.test(pw)
-}
+import ResetPasswordSection from '@/components/auth/resetPassword/ResetPasswordSection'
 
 export default function ResetPasswordPage() {
-  const [newPassword, setNewPassword] = useState('')
-  const [confirm, setConfirm] = useState('')
+  const [emailVerified, setEmailVerified] = useState(false)
+  const [newPasswordVerified, setNewPasswordVerified] = useState(false)
 
-  const newPasswordStatus = !newPassword
-    ? 'default'
-    : isValidNewPassword(newPassword)
-      ? 'success'
-      : 'error'
+  const canSubmit = emailVerified && newPasswordVerified
 
-  const confirmStatus = !confirm
-    ? 'default'
-    : confirm === newPassword
-      ? 'success'
-      : 'error'
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+
+    if (!canSubmit) return
+
+    console.log('비밀번호 재설정 완료') //TODO: 비밀번호 재설정 API 연동
+  }
 
   return (
-    <main className="min-w-102.5 mx-auto py-12">
-      <div className="pb-3.75 mb-13.5 border-b border-gray5">
-        <h1 className="text-xl font-bold">비밀번호 재설정</h1>
-      </div>
+    <main className="min-h-screen py-12 flex flex-col justify-center">
+      <div className="mx-auto flex w-full max-w-[410px] flex-col justify-center">
+        <div className="pb-3.75 mb-13.5 border-b border-gray5">
+          <h1 className="text-xl font-bold">비밀번호 재설정</h1>
+        </div>
 
-      <EmailSection />
-
-      <div className="flex flex-col gap-5.5">
-        <PasswordField
-          label="새 비밀번호"
-          name="newPassword"
-          value={newPassword}
-          placeholder="새 비밀번호를 입력해주세요."
-          status={newPasswordStatus}
-          helperText="영문, 숫자, 특수문자를 포함하여 8자 이상 입력해주세요."
-          onChange={setNewPassword}
-        />
-        <PasswordField
-          label="새 비밀번호 확인"
-          name="newPasswordConfirm"
-          value={confirm}
-          onChange={setConfirm}
-          placeholder="비밀번호를 입력해주세요."
-          status={confirmStatus}
-          helperText={
-            confirm
-              ? confirm === newPassword
-                ? '비밀번호가 일치합니다.'
-                : '비밀번호가 일치하지 않습니다.'
-              : '\u00A0'
-          }
-        />
+        <form onSubmit={handleSubmit} className="flex flex-col gap-6">
+          <EmailSection onEmailVerified={setEmailVerified} />
+          <ResetPasswordSection onPasswordValid={setNewPasswordVerified} />
+          <Button
+            type="submit"
+            variant={canSubmit ? 'primary' : 'secondary'}
+            disabled={!canSubmit}
+            className="w-full"
+          >
+            변경 완료
+          </Button>
+        </form>
       </div>
     </main>
   )

--- a/src/app/(auth)/reset-password/page.tsx
+++ b/src/app/(auth)/reset-password/page.tsx
@@ -1,0 +1,11 @@
+import EmailSection from '@/components/auth/signup/EmailSection'
+import PasswordSection from '@/components/auth/signup/PasswordSection'
+
+export default function ResetPasswordPage() {
+  ;<main className="min-w-102.5 mx-auto py-12">
+    <div className="pb-3.75 mb-13.5 border-b border-gray5">
+      <h1 className="text-xl font-bold">비밀번호 재설정</h1>
+    </div>
+    <EmailSection />
+  </main>
+}

--- a/src/app/(auth)/reset-password/page.tsx
+++ b/src/app/(auth)/reset-password/page.tsx
@@ -1,11 +1,66 @@
+'use client'
+
+import { useState } from 'react'
 import EmailSection from '@/components/auth/signup/EmailSection'
-import PasswordSection from '@/components/auth/signup/PasswordSection'
+import PasswordField from '@/components/common/input/PasswordField'
+
+const PASSWORD_REGEX =
+  /^(?=.*[a-zA-Z])(?=.*\d)(?=.*[!@#$%^&*()_+\-=[\]{};':"\\|,.<>/?]).{8,}$/
+
+function isValidNewPassword(pw: string) {
+  return PASSWORD_REGEX.test(pw)
+}
 
 export default function ResetPasswordPage() {
-  ;<main className="min-w-102.5 mx-auto py-12">
-    <div className="pb-3.75 mb-13.5 border-b border-gray5">
-      <h1 className="text-xl font-bold">비밀번호 재설정</h1>
-    </div>
-    <EmailSection />
-  </main>
+  const [newPassword, setNewPassword] = useState('')
+  const [confirm, setConfirm] = useState('')
+
+  const newPasswordStatus = !newPassword
+    ? 'default'
+    : isValidNewPassword(newPassword)
+      ? 'success'
+      : 'error'
+
+  const confirmStatus = !confirm
+    ? 'default'
+    : confirm === newPassword
+      ? 'success'
+      : 'error'
+
+  return (
+    <main className="min-w-102.5 mx-auto py-12">
+      <div className="pb-3.75 mb-13.5 border-b border-gray5">
+        <h1 className="text-xl font-bold">비밀번호 재설정</h1>
+      </div>
+
+      <EmailSection />
+
+      <div className="flex flex-col gap-5.5">
+        <PasswordField
+          label="새 비밀번호"
+          name="newPassword"
+          value={newPassword}
+          placeholder="새 비밀번호를 입력해주세요."
+          status={newPasswordStatus}
+          helperText="영문, 숫자, 특수문자를 포함하여 8자 이상 입력해주세요."
+          onChange={setNewPassword}
+        />
+        <PasswordField
+          label="새 비밀번호 확인"
+          name="newPasswordConfirm"
+          value={confirm}
+          onChange={setConfirm}
+          placeholder="비밀번호를 입력해주세요."
+          status={confirmStatus}
+          helperText={
+            confirm
+              ? confirm === newPassword
+                ? '비밀번호가 일치합니다.'
+                : '비밀번호가 일치하지 않습니다.'
+              : '\u00A0'
+          }
+        />
+      </div>
+    </main>
+  )
 }

--- a/src/components/auth/resetPassword/ResetPasswordSection.tsx
+++ b/src/components/auth/resetPassword/ResetPasswordSection.tsx
@@ -44,6 +44,7 @@ export default function ResetPasswordSection({
         status={newPasswordStatus}
         helperText="영문, 숫자, 특수문자를 포함하여 8자 이상 입력해주세요."
         onChange={setNewPassword}
+        showDash
       />
 
       <PasswordField

--- a/src/components/auth/resetPassword/ResetPasswordSection.tsx
+++ b/src/components/auth/resetPassword/ResetPasswordSection.tsx
@@ -1,9 +1,6 @@
 import { useState, useEffect } from 'react'
 import PasswordField from '@/components/common/input/PasswordField'
 
-const PASSWORD_REGEX =
-  /^(?=.*[a-zA-Z])(?=.*\d)(?=.*[!@#$%^&*()_+\-=[\]{};':"\\|,.<>/?]).{8,}$/
-
 function isValidNewPassword(pw: string) {
   return PASSWORD_REGEX.test(pw)
 }
@@ -20,9 +17,7 @@ export default function ResetPasswordSection({
 
   useEffect(() => {
     onPasswordValid?.(
-      isValidNewPassword(newPassword) &&
-        newPassword === confirm &&
-        confirm !== '',
+      isValidNewPassword(newPassword) && newPassword === confirm,
     )
   }, [newPassword, confirm, onPasswordValid])
 

--- a/src/components/auth/resetPassword/ResetPasswordSection.tsx
+++ b/src/components/auth/resetPassword/ResetPasswordSection.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react'
+import { PASSWORD_REGEX } from '@/constants/regex'
 import PasswordField from '@/components/common/input/PasswordField'
 
 function isValidNewPassword(pw: string) {

--- a/src/components/auth/resetPassword/ResetPasswordSection.tsx
+++ b/src/components/auth/resetPassword/ResetPasswordSection.tsx
@@ -1,0 +1,70 @@
+import { useState, useEffect } from 'react'
+import PasswordField from '@/components/common/input/PasswordField'
+
+const PASSWORD_REGEX =
+  /^(?=.*[a-zA-Z])(?=.*\d)(?=.*[!@#$%^&*()_+\-=[\]{};':"\\|,.<>/?]).{8,}$/
+
+function isValidNewPassword(pw: string) {
+  return PASSWORD_REGEX.test(pw)
+}
+
+interface ResetPasswordSectionProps {
+  onPasswordValid?: (valid: boolean) => void
+}
+
+export default function ResetPasswordSection({
+  onPasswordValid,
+}: ResetPasswordSectionProps) {
+  const [newPassword, setNewPassword] = useState('')
+  const [confirm, setConfirm] = useState('')
+
+  useEffect(() => {
+    onPasswordValid?.(
+      isValidNewPassword(newPassword) &&
+        newPassword === confirm &&
+        confirm !== '',
+    )
+  }, [newPassword, confirm, onPasswordValid])
+
+  const newPasswordStatus = !newPassword
+    ? 'default'
+    : isValidNewPassword(newPassword)
+      ? 'success'
+      : 'error'
+
+  const confirmStatus = !confirm
+    ? 'default'
+    : confirm === newPassword
+      ? 'success'
+      : 'error'
+
+  return (
+    <div className="flex flex-col gap-5.5">
+      <PasswordField
+        label="새 비밀번호"
+        name="newPassword"
+        value={newPassword}
+        placeholder="새 비밀번호를 입력해주세요."
+        status={newPasswordStatus}
+        helperText="영문, 숫자, 특수문자를 포함하여 8자 이상 입력해주세요."
+        onChange={setNewPassword}
+      />
+
+      <PasswordField
+        label="새 비밀번호 확인"
+        name="newPasswordConfirm"
+        value={confirm}
+        onChange={setConfirm}
+        placeholder="비밀번호를 입력해주세요."
+        status={confirmStatus}
+        helperText={
+          confirm
+            ? confirm === newPassword
+              ? '비밀번호가 일치합니다.'
+              : '비밀번호가 일치하지 않습니다.'
+            : '\u00A0'
+        }
+      />
+    </div>
+  )
+}

--- a/src/components/auth/signup/EmailSection.tsx
+++ b/src/components/auth/signup/EmailSection.tsx
@@ -5,8 +5,6 @@ import Button from '@/components/common/button/Button'
 import InputBox from '@/components/common/input/InputBox'
 import HelperText from '@/components/common/text/HelperText'
 
-const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
-
 type FieldStatus = 'default' | 'success' | 'error'
 type HelperStatus = FieldStatus | 'empty'
 

--- a/src/components/auth/signup/EmailSection.tsx
+++ b/src/components/auth/signup/EmailSection.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useRef, useState } from 'react'
+import { EMAIL_REGEX } from '@/constants/regex'
 import Button from '@/components/common/button/Button'
 import InputBox from '@/components/common/input/InputBox'
 import HelperText from '@/components/common/text/HelperText'

--- a/src/components/auth/signup/NicknameSection.tsx
+++ b/src/components/auth/signup/NicknameSection.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState } from 'react'
+import { NICKNAME_REGEX } from '@/constants/regex'
 import Button from '@/components/common/button/Button'
 import InputBox from '@/components/common/input/InputBox'
 import HelperText from '@/components/common/text/HelperText'

--- a/src/components/auth/signup/NicknameSection.tsx
+++ b/src/components/auth/signup/NicknameSection.tsx
@@ -5,8 +5,6 @@ import Button from '@/components/common/button/Button'
 import InputBox from '@/components/common/input/InputBox'
 import HelperText from '@/components/common/text/HelperText'
 
-const NICKNAME_REGEX = /[^a-zA-Z0-9가-힣]/
-
 type HelperState = {
   text: string
   status: 'default' | 'success' | 'error' | 'empty'

--- a/src/components/auth/signup/PasswordSection.tsx
+++ b/src/components/auth/signup/PasswordSection.tsx
@@ -46,7 +46,7 @@ export default function PasswordSection({
         onChange={setPassword}
         placeholder="비밀번호를 입력해주세요."
         status={passwordStatus}
-        helperText="- 영문, 숫자, 특수문자를 포함하여 8자 이상 입력해주세요."
+        helperText="영문, 숫자, 특수문자를 포함하여 8자 이상 입력해주세요."
       />
 
       <PasswordField

--- a/src/components/auth/signup/PasswordSection.tsx
+++ b/src/components/auth/signup/PasswordSection.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useState } from 'react'
+import { PASSWORD_REGEX } from '@/constants/regex'
 import PasswordField from '@/components/common/input/PasswordField'
 
 function isValidPassword(pw: string) {

--- a/src/components/auth/signup/PasswordSection.tsx
+++ b/src/components/auth/signup/PasswordSection.tsx
@@ -3,9 +3,6 @@
 import { useEffect, useState } from 'react'
 import PasswordField from '@/components/common/input/PasswordField'
 
-const PASSWORD_REGEX =
-  /^(?=.*[a-zA-Z])(?=.*\d)(?=.*[!@#$%^&*()_+\-=[\]{};':"\\|,.<>/?]).{8,}$/
-
 function isValidPassword(pw: string) {
   return PASSWORD_REGEX.test(pw)
 }

--- a/src/components/auth/signup/PasswordSection.tsx
+++ b/src/components/auth/signup/PasswordSection.tsx
@@ -1,14 +1,10 @@
 'use client'
 
 import { useEffect, useState } from 'react'
-import Image from 'next/image'
-import VisibleIcon from '@/assets/icon/visible-icon.svg'
-import InvisibleIcon from '@/assets/icon/invisible-icon.svg'
-import InputBox from '@/components/common/input/InputBox'
+import PasswordField from '@/components/common/input/PasswordField'
 
 const PASSWORD_REGEX =
   /^(?=.*[a-zA-Z])(?=.*\d)(?=.*[!@#$%^&*()_+\-=[\]{};':"\\|,.<>/?]).{8,}$/
-import HelperText from '@/components/common/text/HelperText'
 
 function isValidPassword(pw: string) {
   return PASSWORD_REGEX.test(pw)
@@ -23,8 +19,6 @@ export default function PasswordSection({
 }: PasswordSectionProps) {
   const [password, setPassword] = useState('')
   const [confirm, setConfirm] = useState('')
-  const [showPassword, setShowPassword] = useState(false)
-  const [showConfirm, setShowConfirm] = useState(false)
 
   useEffect(() => {
     onPasswordValid?.(
@@ -45,87 +39,31 @@ export default function PasswordSection({
 
   return (
     <div className="flex flex-col gap-5.5">
-      <div className="flex flex-col gap-2">
-        <label className="font-medium mb-1.75" htmlFor="password">
-          비밀번호
-        </label>
-        <InputBox
-          id="password"
-          type={showPassword ? 'text' : 'password'}
-          name="password"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-          placeholder="비밀번호를 입력해주세요."
-          status={passwordStatus}
-          aria-describedby="password-desc"
-          rightElement={
-            <button
-              type="button"
-              aria-label="비밀번호 보기 토글"
-              onClick={() => setShowPassword((v) => !v)}
-            >
-              <Image
-                src={showPassword ? VisibleIcon : InvisibleIcon}
-                alt={showPassword ? '비밀번호 숨기기' : '비밀번호 보기'}
-                width={24}
-                height={24}
-              />
-            </button>
-          }
-        />
-        <HelperText
-          id="password-desc"
-          status={
-            !password
-              ? 'default'
-              : isValidPassword(password)
-                ? 'success'
-                : 'error'
-          }
-        >
-          - 영문, 숫자, 특수문자를 포함하여 8자 이상 입력해주세요.
-        </HelperText>
-      </div>
+      <PasswordField
+        label="비밀번호"
+        name="password"
+        value={password}
+        onChange={setPassword}
+        placeholder="비밀번호를 입력해주세요."
+        status={passwordStatus}
+        helperText="- 영문, 숫자, 특수문자를 포함하여 8자 이상 입력해주세요."
+      />
 
-      <div className="flex flex-col gap-2">
-        <label className="font-medium mb-1.75" htmlFor="passwordConfirm">
-          비밀번호 확인
-        </label>
-        <InputBox
-          id="passwordConfirm"
-          type={showConfirm ? 'text' : 'password'}
-          name="passwordConfirm"
-          value={confirm}
-          onChange={(e) => setConfirm(e.target.value)}
-          placeholder="비밀번호를 입력해주세요."
-          status={confirmStatus}
-          aria-describedby="passwordConfirm-desc"
-          rightElement={
-            <button
-              type="button"
-              aria-label="비밀번호 확인 보기 토글"
-              onClick={() => setShowConfirm((v) => !v)}
-            >
-              <Image
-                src={showConfirm ? VisibleIcon : InvisibleIcon}
-                alt={showConfirm ? '비밀번호 숨기기' : '비밀번호 보기'}
-                width={24}
-                height={24}
-              />
-            </button>
-          }
-        />
-        <HelperText
-          id="passwordConfirm-desc"
-          status={confirm ? confirmStatus : 'empty'}
-        >
-          {confirm
+      <PasswordField
+        label="비밀번호 확인"
+        name="passwordConfirm"
+        value={confirm}
+        onChange={setConfirm}
+        placeholder="비밀번호를 입력해주세요."
+        status={confirmStatus}
+        helperText={
+          confirm
             ? confirm === password
               ? '비밀번호가 일치합니다.'
               : '비밀번호가 일치하지 않습니다.'
-            : '\u00A0'}
-        </HelperText>
-      </div>
+            : '\u00A0'
+        }
+      />
     </div>
   )
 }

--- a/src/components/auth/signup/PasswordSection.tsx
+++ b/src/components/auth/signup/PasswordSection.tsx
@@ -45,6 +45,7 @@ export default function PasswordSection({
         placeholder="비밀번호를 입력해주세요."
         status={passwordStatus}
         helperText="영문, 숫자, 특수문자를 포함하여 8자 이상 입력해주세요."
+        showDash
       />
 
       <PasswordField

--- a/src/components/auth/signup/SignUpForm.tsx
+++ b/src/components/auth/signup/SignUpForm.tsx
@@ -13,9 +13,13 @@ export default function SignUpForm() {
   const [nicknameChecked, setNicknameChecked] = useState(false)
   const [termsAccepted, setTermsAccepted] = useState(false)
 
-  const handlePasswordValid = useCallback((valid: boolean) => setPasswordValid(valid), [])
+  const handlePasswordValid = useCallback(
+    (valid: boolean) => setPasswordValid(valid),
+    [],
+  )
 
-  const canSubmit = emailVerified && passwordValid && nicknameChecked && termsAccepted
+  const canSubmit =
+    emailVerified && passwordValid && nicknameChecked && termsAccepted
 
   return (
     <form className="flex flex-col gap-5.5">

--- a/src/components/common/input/InputBox.tsx
+++ b/src/components/common/input/InputBox.tsx
@@ -23,7 +23,8 @@ export default function InputBox({
         <input
           {...props}
           className={`
-            w-full px-4 py-3.5 text-base rounded-lg border outline-text-primary
+            w-full px-4 py-3.5 text-base rounded-lg border outline-none
+            focus:border-text-primary transition-colors duration-250 ease-in-out
             placeholder:text-secondary disabled:cursor-not-allowed
             ${rightElement ? 'pr-12' : ''}
             ${borderClass}
@@ -31,7 +32,9 @@ export default function InputBox({
           `}
         />
         {rightElement && (
-          <div className="absolute right-4 inset-y-0 flex items-center">{rightElement}</div>
+          <div className="absolute right-4 inset-y-0 flex items-center">
+            {rightElement}
+          </div>
         )}
       </div>
     </div>

--- a/src/components/common/input/InputBox.tsx
+++ b/src/components/common/input/InputBox.tsx
@@ -12,9 +12,9 @@ export default function InputBox({
   ...props
 }: InputBoxProps) {
   const borderClass = {
-    default: 'border-secondary',
-    success: 'border-secondary',
-    error: 'border-text-point-red',
+    default: 'border-secondary focus:border-text-primary',
+    success: 'border-secondary focus:border-primary',
+    error: 'border-text-point-red focus:border-text-point-red',
   }[status]
 
   return (
@@ -24,7 +24,7 @@ export default function InputBox({
           {...props}
           className={`
             w-full px-4 py-3.5 text-base rounded-lg border outline-none
-            focus:border-text-primary transition-colors duration-250 ease-in-out
+            transition-colors duration-250 ease-in-out
             placeholder:text-secondary disabled:cursor-not-allowed
             ${rightElement ? 'pr-12' : ''}
             ${borderClass}

--- a/src/components/common/input/PasswordField.tsx
+++ b/src/components/common/input/PasswordField.tsx
@@ -1,0 +1,67 @@
+'use client'
+
+import { useState } from 'react'
+import Image from 'next/image'
+import VisibleIcon from '@/assets/icon/visible-icon.svg'
+import InvisibleIcon from '@/assets/icon/invisible-icon.svg'
+import InputBox from '@/components/common/input/InputBox'
+import HelperText from '@/components/common/text/HelperText'
+
+type FieldStatus = 'default' | 'success' | 'error' | 'empty'
+
+interface PasswordFieldProps {
+  label: string
+  name: string
+  value: string
+  placeholder: string
+  status: FieldStatus
+  helperText: string
+  onChange: (value: string) => void
+}
+
+export default function PasswordField({
+  label,
+  name,
+  value,
+  placeholder,
+  status,
+  helperText,
+  onChange,
+}: PasswordFieldProps) {
+  const [show, setShow] = useState(false)
+
+  return (
+    <div className="flex flex-col gap-2">
+      <label className="font-medium mb-1.75" htmlFor={name}>
+        {label}
+      </label>
+      <InputBox
+        id={name}
+        type={show ? 'text' : 'password'}
+        name={name}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        status={status === 'empty' ? 'default' : status}
+        aria-describedby={`${name}-desc`}
+        rightElement={
+          <button
+            type="button"
+            aria-label={show ? '비밀번호 숨기기' : '비밀번호 보기'}
+            onClick={() => setShow((v) => !v)}
+          >
+            <Image
+              src={show ? VisibleIcon : InvisibleIcon}
+              alt=""
+              width={24}
+              height={24}
+            />
+          </button>
+        }
+      />
+      <HelperText id={`${name}-desc`} status={status}>
+        {helperText}
+      </HelperText>
+    </div>
+  )
+}

--- a/src/components/common/input/PasswordField.tsx
+++ b/src/components/common/input/PasswordField.tsx
@@ -16,6 +16,7 @@ interface PasswordFieldProps {
   placeholder: string
   status: FieldStatus
   helperText: string
+  showDash?: boolean
   onChange: (value: string) => void
 }
 
@@ -26,6 +27,7 @@ export default function PasswordField({
   placeholder,
   status,
   helperText,
+  showDash,
   onChange,
 }: PasswordFieldProps) {
   const [show, setShow] = useState(false)
@@ -59,7 +61,7 @@ export default function PasswordField({
           </button>
         }
       />
-      <HelperText id={`${name}-desc`} status={status}>
+      <HelperText id={`${name}-desc`} status={status} showDash={showDash}>
         {helperText}
       </HelperText>
     </div>

--- a/src/components/common/text/HelperText.tsx
+++ b/src/components/common/text/HelperText.tsx
@@ -7,6 +7,7 @@ interface HelperTextProps {
   status?: 'default' | 'success' | 'error' | 'empty'
   id?: string
   visible?: boolean
+  showDash?: boolean
 }
 
 export default function HelperText({
@@ -14,6 +15,7 @@ export default function HelperText({
   status = 'default',
   id,
   visible = true,
+  showDash = false,
 }: HelperTextProps) {
   if (!visible) return null
 
@@ -50,6 +52,7 @@ export default function HelperText({
   return (
     <span id={id} className={`flex items-center gap-1 text-sm ${colorClass}`}>
       {icon}
+      {showDash && status === 'default' && <span>-</span>}
       {children}
     </span>
   )

--- a/src/constants/regex.ts
+++ b/src/constants/regex.ts
@@ -1,6 +1,6 @@
-const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+export const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
 
-const PASSWORD_REGEX =
+export const PASSWORD_REGEX =
   /^(?=.*[a-zA-Z])(?=.*\d)(?=.*[!@#$%^&*()_+\-=[\]{};':"\\|,.<>/?]).{8,}$/
 
-const NICKNAME_REGEX = /[^a-zA-Z0-9가-힣]/
+export const NICKNAME_REGEX = /[^a-zA-Z0-9가-힣]/

--- a/src/constants/regex.ts
+++ b/src/constants/regex.ts
@@ -1,0 +1,6 @@
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+const PASSWORD_REGEX =
+  /^(?=.*[a-zA-Z])(?=.*\d)(?=.*[!@#$%^&*()_+\-=[\]{};':"\\|,.<>/?]).{8,}$/
+
+const NICKNAME_REGEX = /[^a-zA-Z0-9가-힣]/


### PR DESCRIPTION
## ✨ 작업 내용

> 작업한 내용에 대한 설명을 적어주세요

- 비밀번호 재설정 페이지를 퍼블리싱하였습니다.
- 반복되던 비밀번호 입력 필드와 HelperText 로직을 재사용 가능하도록 `PasswordField` 컴포넌트로 분리하였습니다.

  ```
  <PasswordField
          label="비밀번호"
          name="password"
          value={password}
          onChange={setPassword}
          placeholder="비밀번호를 입력해주세요."
          status={passwordStatus}
          helperText="영문, 숫자, 특수문자를 포함하여 8자 이상 입력해주세요."
        />
  ```
  
## 🧩 백그라운드

> 작업이 필요했던 문제 상황을 적어주세요

## 📸 스크린샷(선택)

> 스크린샷이 필요한 작업이면 스크린샷을 첨부해주세요

<img width="740" height="840" alt="스크린샷 2026-04-18 오후 7 32 04" src="https://github.com/user-attachments/assets/15592b69-f140-4dc9-b917-c2b962f2f595" />


## ✅ 테스트

- [x] 정상 동작 확인

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

> 참고할 사항이 있다면 적어주세요
