### PR TITLE
[11-295] 에러 페이지 생성

### DIFF
--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect } from 'react'
 import Link from 'next/link'
+import { IconAlertTriangle } from '@tabler/icons-react'
 
 interface Props {
   error: Error & { digest?: string }
@@ -21,20 +22,7 @@ export default function Error({ error, unstable_retry }: Props) {
       <div className="overflow-hidden w-full max-w-md bg-white/10 backdrop-blur-md rounded-xl shadow-2xl border border-red-500/20">
         <div className="p-6">
           <div className="flex items-center justify-center w-16 h-16 mx-auto mb-4 rounded-full bg-red-600/20">
-            <svg
-              fill="none"
-              className="w-10 h-10 text-red-500"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              aria-hidden="true"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={1.75}
-                d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
-              />
-            </svg>
+            <IconAlertTriangle className="w-10 h-10 text-red-500" aria-hidden="true" />
           </div>
 
           <h1 className="mb-2 text-2xl text-center text-white font-light tracking-wide">

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,11 +1,18 @@
 'use client'
 
+import { useEffect } from 'react'
+import Link from 'next/link'
+
 interface Props {
   error: Error & { digest?: string }
   unstable_retry: () => void
 }
 
 export default function Error({ error, unstable_retry }: Props) {
+  useEffect(() => {
+    console.error(error)
+  }, [error])
+
   return (
     <div
       role="alert"
@@ -31,12 +38,12 @@ export default function Error({ error, unstable_retry }: Props) {
           </div>
 
           <h1 className="mb-2 text-2xl text-center text-white font-light tracking-wide">
-            {error.name}
+            오류가 발생했습니다
           </h1>
           <div className="h-0.5 w-16 bg-red-500/50 mx-auto mb-4" aria-hidden="true" />
 
           <div className="text-red-100/80 text-center mb-6 font-light">
-            <p>{error.message}</p>
+            <p>잠시 후 다시 시도해 주세요.</p>
             {error.digest && (
               <p className="mt-2 text-xs text-red-300/60 font-mono">
                 <span className="sr-only">오류 ID: </span>
@@ -45,7 +52,13 @@ export default function Error({ error, unstable_retry }: Props) {
             )}
           </div>
 
-          <div className="flex justify-center">
+          <div className="flex justify-center gap-3">
+            <Link
+              href="/"
+              className="px-6 py-2.5 bg-white/10 text-white font-medium rounded-lg shadow-lg transition-all duration-200 hover:bg-white/20"
+            >
+              홈으로
+            </Link>
             <button
               type="button"
               onClick={unstable_retry}

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,62 @@
+'use client'
+
+interface Props {
+  error: Error & { digest?: string }
+  unstable_retry: () => void
+}
+
+export default function Error({ error, unstable_retry }: Props) {
+  return (
+    <div
+      role="alert"
+      className="min-h-screen flex items-center justify-center bg-linear-to-br from-red-900 to-gray-900 p-4"
+    >
+      <div className="overflow-hidden w-full max-w-md bg-white/10 backdrop-blur-md rounded-xl shadow-2xl border border-red-500/20">
+        <div className="p-6">
+          <div className="flex items-center justify-center w-16 h-16 mx-auto mb-4 rounded-full bg-red-600/20">
+            <svg
+              fill="none"
+              className="w-10 h-10 text-red-500"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={1.75}
+                d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+              />
+            </svg>
+          </div>
+
+          <h1 className="mb-2 text-2xl text-center text-white font-light tracking-wide">
+            {error.name}
+          </h1>
+          <div className="h-0.5 w-16 bg-red-500/50 mx-auto mb-4" aria-hidden="true" />
+
+          <div className="text-red-100/80 text-center mb-6 font-light">
+            <p>{error.message}</p>
+            {error.digest && (
+              <p className="mt-2 text-xs text-red-300/60 font-mono">
+                <span className="sr-only">오류 ID: </span>
+                {error.digest}
+              </p>
+            )}
+          </div>
+
+          <div className="flex justify-center">
+            <button
+              type="button"
+              onClick={unstable_retry}
+              aria-label="페이지 복구 시도하기"
+              className="cursor-pointer px-6 py-2.5 bg-linear-to-r from-red-600 to-red-700 text-white font-medium rounded-lg shadow-lg transition-all duration-200 transform hover:from-red-700 hover:to-red-800 hover:-translate-y-0.5 active:translate-y-0 focus:ring-2 focus:ring-red-500 focus:ring-opacity-20 focus:outline-none"
+            >
+              복구하기
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## ✨ 작업 내용

> 작업한 내용에 대한 설명을 적어주세요
- 개발자, 사용자가 보게 될 에러 화면을 구현했습니다.

## 🧩 백그라운드

> 작업이 필요했던 문제 상황을 적어주세요
- 개발 환경 : 스택 트레이스가 그대로 노출되어 코드 구조가 보임
- 프로덕션 : 흰 화면 또는 Next.js 기본 500 페이지가 나와서 사용자가 아무것도 할 수 없음
- 결국 사용자가 새로고침 버튼조차 찾지 못하고 이탈

## 📸 스크린샷(선택)

> 스크린샷이 필요한 작업이면 스크린샷을 첨부해주세요
<img width="1092" height="730" alt="스크린샷 2026-04-21 21 31 05" src="https://github.com/user-attachments/assets/64979a55-1334-48c7-9cce-e4e515e65602" />



## ✅ 테스트

- [x] 정상 동작 확인

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

> 참고할 사항이 있다면 적어주세요
