### PR TITLE
[11-300] global.css에 폰트 스타일 저장 및 스타일 수정

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -22,7 +22,7 @@ export default function Login() {
               id="email"
               type="email"
               placeholder="이메일"
-              className="w-full border-0 border-b border-secondary bg-transparent px-1 pb-4 pt-2 text-lg text-text-primary outline-none focus:border-text-primary placeholder:text-secondary transition-all duration-300 ease-in-out"
+              className="w-full border-0 border-b border-secondary bg-transparent px-1 pb-4 pt-2 p1 text-text-primary outline-none focus:border-text-primary placeholder:text-secondary transition-all duration-300 ease-in-out"
             />
           </div>
 
@@ -35,19 +35,19 @@ export default function Login() {
               id="password"
               type="password"
               placeholder="비밀번호"
-              className="w-full border-0 border-b border-secondary bg-transparent px-1 pb-4 pt-2 text-lg text-text-primary outline-none focus:border-text-primary placeholder:text-secondary transition-all duration-300 ease-in-out"
+              className="w-full border-0 border-b border-secondary bg-transparent px-1 pb-4 pt-2 p1 text-text-primary outline-none focus:border-text-primary placeholder:text-secondary transition-all duration-300 ease-in-out"
             />
           </div>
 
           <button
             type="submit"
-            className="mb-10 h-[56px] w-full rounded-md bg-primary text-xl font-bold text-white cursor-pointer"
+            className="mb-10 h-[56px] w-full rounded-md bg-primary h4 text-white cursor-pointer"
           >
             로그인
           </button>
         </form>
 
-        <div className="font-medium mb-12 flex items-center justify-center gap-4 text-md text-text-primary">
+        <div className="p4 mb-12 flex items-center justify-center gap-4 text-text-primary">
           <button type="button" className="cursor-pointer">
             비밀번호 찾기
           </button>

--- a/src/app/(auth)/reset-password/page.tsx
+++ b/src/app/(auth)/reset-password/page.tsx
@@ -23,7 +23,7 @@ export default function ResetPasswordPage() {
     <main className="min-h-screen py-12 flex flex-col justify-center">
       <div className="mx-auto flex w-full max-w-[410px] flex-col justify-center">
         <div className="pb-3.75 mb-13.5 border-b border-gray5">
-          <h1 className="text-xl font-bold">비밀번호 재설정</h1>
+          <h1 className="h4">비밀번호 재설정</h1>
         </div>
 
         <form onSubmit={handleSubmit} className="flex flex-col gap-6">

--- a/src/app/(auth)/sign-up/page.tsx
+++ b/src/app/(auth)/sign-up/page.tsx
@@ -4,7 +4,7 @@ export default function SignUpPage() {
   return (
     <main className="min-w-102.5 mx-auto py-12">
       <div className="pb-3.75 mb-13.5 border-b border-gray5">
-        <h1 className="text-xl font-bold">회원가입</h1>
+        <h1 className="h4">회원가입</h1>
       </div>
       <SignUpForm />
     </main>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -40,3 +40,60 @@ body {
   color: var(--text-primary);
   font-family: var(--font-pretendard), sans-serif;
 }
+
+@layer utilities {
+  .h1 {
+    font-size: 32px;
+    font-weight: 700;
+    line-height: 150%;
+    letter-spacing: -0.03em;
+  }
+  .h2 {
+    font-size: 24px;
+    font-weight: 700;
+    line-height: 150%;
+    letter-spacing: -0.03em;
+  }
+  .h3 {
+    font-size: 22px;
+    font-weight: 700;
+    line-height: 150%;
+    letter-spacing: -0.03em;
+  }
+  .h4 {
+    font-size: 20px;
+    font-weight: 700;
+    line-height: 150%;
+    letter-spacing: -0.03em;
+  }
+  .p1 {
+    font-size: 20px;
+    font-weight: 500;
+    line-height: 150%;
+    letter-spacing: -0.03em;
+  }
+  .p2 {
+    font-size: 18px;
+    font-weight: 700;
+    line-height: 150%;
+    letter-spacing: -0.02em;
+  }
+  .p3 {
+    font-size: 18px;
+    font-weight: 500;
+    line-height: 150%;
+    letter-spacing: -0.02em;
+  }
+  .p4 {
+    font-size: 16px;
+    font-weight: 500;
+    line-height: 150%;
+    letter-spacing: -0.02em;
+  }
+  .caption {
+    font-size: 14px;
+    font-weight: 500;
+    line-height: 150%;
+    letter-spacing: -0.02em;
+  }
+}

--- a/src/components/auth/signup/EmailSection.tsx
+++ b/src/components/auth/signup/EmailSection.tsx
@@ -102,7 +102,7 @@ export default function EmailSection({ onEmailVerified }: EmailSectionProps) {
 
   return (
     <div className="flex flex-col gap-2">
-      <label className="font-medium mb-1.75" htmlFor="email">
+      <label className="p4 mb-1.75" htmlFor="email">
         이메일
       </label>
       <div className="flex flex-col gap-2">
@@ -141,7 +141,7 @@ export default function EmailSection({ onEmailVerified }: EmailSectionProps) {
             status={codeStatus}
             rightElement={
               timeLeft !== null && timeLeft > 0 ? (
-                <span className="text-sm text-primary">
+                <span className="caption text-primary">
                   {formatTime(timeLeft)}
                 </span>
               ) : undefined

--- a/src/components/auth/signup/NicknameSection.tsx
+++ b/src/components/auth/signup/NicknameSection.tsx
@@ -55,7 +55,7 @@ export default function NicknameSection({
 
   return (
     <div className="flex flex-col gap-2">
-      <label className="font-medium mb-1.75" htmlFor="nickname">
+      <label className="p4 mb-1.75" htmlFor="nickname">
         닉네임
       </label>
       <div className="flex gap-2.75">

--- a/src/components/auth/signup/TermsSection.tsx
+++ b/src/components/auth/signup/TermsSection.tsx
@@ -32,7 +32,7 @@ export default function TermsSection({ onAcceptChange }: TermsSectionProps) {
 
   return (
     <fieldset>
-      <div className="h-10 border-b border-secondary text-xl font-bold mt-8 mb-9.5 flex">
+      <div className="h-10 border-b border-secondary h4 mt-8 mb-9.5 flex">
         <legend>약관 동의</legend>
       </div>
 

--- a/src/components/common/button/Button.tsx
+++ b/src/components/common/button/Button.tsx
@@ -20,7 +20,7 @@ export default function Button({
       type="button"
       {...props}
       className={`
-        text-base rounded-lg font-medium whitespace-nowrap min-w-22.25 px-4 py-3.5 cursor-pointer
+        p4 rounded-lg whitespace-nowrap min-w-22.25 px-4 py-3.5 cursor-pointer
         disabled:opacity-50 disabled:cursor-not-allowed
         ${variantStyle}
         ${className ?? ''}

--- a/src/components/common/header/Header.tsx
+++ b/src/components/common/header/Header.tsx
@@ -3,7 +3,11 @@
 import Image from 'next/image'
 import Link from 'next/link'
 import { useState, useRef, useEffect } from 'react'
-import { IconChevronDown, IconSettingsFilled, IconUserFilled } from '@tabler/icons-react'
+import {
+  IconChevronDown,
+  IconSettingsFilled,
+  IconUserFilled,
+} from '@tabler/icons-react'
 
 interface HeaderProps {
   className?: string
@@ -56,11 +60,7 @@ export default function Header({
           className="flex items-center gap-15.25 mr-14.25"
         >
           {NAV_LINKS.map(({ href, label }) => (
-            <Link
-              key={href}
-              href={href}
-              className="text-xl font-medium hover:text-primary"
-            >
+            <Link key={href} href={href} className="p1 hover:text-primary">
               {label}
             </Link>
           ))}
@@ -71,7 +71,7 @@ export default function Header({
             className="w-7.5 h-7.5 rounded-full bg-primary mr-3.25"
             aria-hidden="true"
           />
-          <span className="text-xl font-medium mr-3.75">{userName} 님</span>
+          <span className="p1 mr-3.75">{userName} 님</span>
 
           <div className="relative">
             <button
@@ -102,9 +102,13 @@ export default function Header({
                   href="/settings"
                   role="menuitem"
                   onClick={() => setOpen(false)}
-                  className="flex items-center justify-center gap-2.5 px-8 py-4.25 font-medium hover:text-primary"
+                  className="flex items-center justify-center gap-2.5 px-8 py-4.25 p4 hover:text-primary"
                 >
-                  <IconSettingsFilled size={24} aria-hidden="true" className="shrink-0" />
+                  <IconSettingsFilled
+                    size={24}
+                    aria-hidden="true"
+                    className="shrink-0"
+                  />
                   환경설정
                 </Link>
                 <div className="h-px bg-gray5 mx-3" aria-hidden="true" />
@@ -112,9 +116,13 @@ export default function Header({
                   type="button"
                   role="menuitem"
                   onClick={() => setOpen(false)}
-                  className="w-full flex items-center justify-center gap-2.5 px-8 py-4.25 font-medium hover:text-primary hover:cursor-pointer"
+                  className="w-full flex items-center justify-center gap-2.5 px-8 py-4.25 p4 hover:text-primary hover:cursor-pointer"
                 >
-                  <IconUserFilled size={24} aria-hidden="true" className="shrink-0" />
+                  <IconUserFilled
+                    size={24}
+                    aria-hidden="true"
+                    className="shrink-0"
+                  />
                   로그아웃
                 </button>
               </div>

--- a/src/components/common/input/InputBox.tsx
+++ b/src/components/common/input/InputBox.tsx
@@ -23,7 +23,7 @@ export default function InputBox({
         <input
           {...props}
           className={`
-            w-full px-4 py-3.5 text-base rounded-lg border outline-none
+            w-full px-4 py-3.5 p4 rounded-lg border outline-none
             transition-colors duration-250 ease-in-out
             placeholder:text-secondary disabled:cursor-not-allowed
             ${rightElement ? 'pr-12' : ''}

--- a/src/components/common/input/PasswordField.tsx
+++ b/src/components/common/input/PasswordField.tsx
@@ -34,7 +34,7 @@ export default function PasswordField({
 
   return (
     <div className="flex flex-col gap-2">
-      <label className="font-medium mb-1.75" htmlFor={name}>
+      <label className="p4 mb-1.75" htmlFor={name}>
         {label}
       </label>
       <InputBox

--- a/src/components/common/text/HelperText.tsx
+++ b/src/components/common/text/HelperText.tsx
@@ -50,7 +50,7 @@ export default function HelperText({
   }[status]
 
   return (
-    <span id={id} className={`flex items-center gap-1 text-sm ${colorClass}`}>
+    <span id={id} className={`flex items-center gap-1 caption ${colorClass}`}>
       {icon}
       {showDash && status === 'default' && <span>-</span>}
       {children}


### PR DESCRIPTION
## ✨ 작업 내용

> 작업한 내용에 대한 설명을 적어주세요
- h1~h4, p1~p4, caption 클래스 정의 (크기, 굵기, 행간, 자간)
- 기존 tailwind 텍스트 클래스를 시멘틱 클래스로 교체

## 🧩 백그라운드

> 작업이 필요했던 문제 상황을 적어주세요
- 컴포넌트마다 Tailwind 텍스트 클래스를 조합해 사용 -> 피그마 디자인 스펙과의 불일치 발생
- 타이포그래피 일관성을 유지 어려움
- 디자인 시스템의 폰트 스펙을 단일 클래스로 관리하기 위해 작업

## 📸 스크린샷(선택)

> 스크린샷이 필요한 작업이면 스크린샷을 첨부해주세요
<img width="375" height="974" alt="스크린샷 2026-04-23 14 36 47" src="https://github.com/user-attachments/assets/8a6fc86c-a33f-4b5f-a5b9-a9a3a35204cc" />

## ✅ 테스트

- [x] 정상 동작 확인

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

> 참고할 사항이 있다면 적어주세요
