### PR TITLE
[11-302] 채용 공고 분석 SSE, 회사명 PATCH API 연동

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,14 +1,15 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "ai-go",
       "dependencies": {
+        "@microsoft/fetch-event-source": "^2.0.1",
         "@tabler/icons-react": "^3.41.1",
         "@tanstack/react-query": "^5.100.5",
         "axios": "^1.15.2",
         "next": "^16.2.4",
-        "postcss": "^8.5.12",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
       },
@@ -161,6 +162,8 @@
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@microsoft/fetch-event-source": ["@microsoft/fetch-event-source@2.0.1", "", {}, "sha512-W6CLUJ2eBMw3Rec70qrsEW0jOm/3twwJv21mrmj2yORiaVmVYGS4sSS5yUwvQc1ZlDLYGPnClVWmUUMagKNsfA=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@0.2.12", "", { "dependencies": { "@emnapi/core": "^1.4.3", "@emnapi/runtime": "^1.4.3", "@tybys/wasm-util": "^0.10.0" } }, "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ=="],
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test:playwright": "playwright test"
   },
   "dependencies": {
+    "@microsoft/fetch-event-source": "^2.0.1",
     "@tabler/icons-react": "^3.41.1",
     "@tanstack/react-query": "^5.100.5",
     "axios": "^1.15.2",

--- a/src/apis/job-postings/index.tsx
+++ b/src/apis/job-postings/index.tsx
@@ -8,7 +8,6 @@ import { ApiResponse } from '../common/type'
 import {
   JobPostingAnalysisRequest,
   JobPosting,
-  JobPostingAnalysisEvent,
   JobPostingDetail,
   JobPostingListItem,
   UpdateJobPostingCompanyNameRequest,
@@ -72,12 +71,6 @@ export const createJobPostingAnalysisEventSource = (
       ...options.headers,
     },
   })
-}
-
-export const parseJobPostingAnalysisEvent = (
-  event: MessageEvent<string>,
-): JobPostingAnalysisEvent => {
-  return JSON.parse(event.data)
 }
 
 export const jobPostingAnalysisFlowApi = {

--- a/src/apis/job-postings/index.tsx
+++ b/src/apis/job-postings/index.tsx
@@ -1,3 +1,8 @@
+import {
+  fetchEventSource,
+  type FetchEventSourceInit,
+} from '@microsoft/fetch-event-source'
+import { getAccessToken } from '@/utils/tokenStorage'
 import { privateClient } from '@/apis/common/privateClient'
 import { ApiResponse } from '../common/type'
 import {
@@ -8,6 +13,8 @@ import {
   JobPostingListItem,
   UpdateJobPostingCompanyNameRequest,
 } from './type'
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL
 
 export const getJobPostingList = async () => {
   const { data } =
@@ -48,8 +55,27 @@ export const updateJobPostingCompanyName = async (
   return data.data
 }
 
-export const createJobPostingAnalysisEventSource = (uuid: string) => {
-  return new EventSource(`/api/job-postings/${uuid}/stream`)
+// export const createJobPostingAnalysisEventSource = (uuid: string) => {
+//   return new EventSource(`${API_BASE_URL}/job-postings/${uuid}/stream`)
+// }
+
+export const createJobPostingAnalysisEventSource = (
+  uuid: string,
+  options: FetchEventSourceInit,
+) => {
+  const accessToken = getAccessToken()
+
+  return fetchEventSource(`${API_BASE_URL}/job-postings/${uuid}/stream`, {
+    ...options,
+
+    credentials: 'include',
+
+    headers: {
+      Accept: 'text/event-stream',
+      Authorization: `Bearer ${accessToken ?? ''}`,
+      ...options.headers,
+    },
+  })
 }
 
 export const parseJobPostingAnalysisEvent = (

--- a/src/apis/job-postings/index.tsx
+++ b/src/apis/job-postings/index.tsx
@@ -55,10 +55,6 @@ export const updateJobPostingCompanyName = async (
   return data.data
 }
 
-// export const createJobPostingAnalysisEventSource = (uuid: string) => {
-//   return new EventSource(`${API_BASE_URL}/job-postings/${uuid}/stream`)
-// }
-
 export const createJobPostingAnalysisEventSource = (
   uuid: string,
   options: FetchEventSourceInit,
@@ -82,4 +78,11 @@ export const parseJobPostingAnalysisEvent = (
   event: MessageEvent<string>,
 ): JobPostingAnalysisEvent => {
   return JSON.parse(event.data)
+}
+
+export const jobPostingAnalysisFlowApi = {
+  createJobPosting,
+  createJobPostingAnalysisEventSource,
+  getJobPosting,
+  updateJobPostingCompanyName,
 }

--- a/src/apis/job-postings/index.tsx
+++ b/src/apis/job-postings/index.tsx
@@ -1,10 +1,12 @@
 import { privateClient } from '@/apis/common/privateClient'
 import { ApiResponse } from '../common/type'
 import {
-  CreateJobPostingRequest,
+  JobPostingAnalysisRequest,
   JobPosting,
+  JobPostingAnalysisEvent,
   JobPostingDetail,
   JobPostingListItem,
+  UpdateJobPostingCompanyNameRequest,
 } from './type'
 
 export const getJobPostingList = async () => {
@@ -13,7 +15,7 @@ export const getJobPostingList = async () => {
   return data.data
 }
 
-export const createJobPosting = async (body: CreateJobPostingRequest) => {
+export const createJobPosting = async (body: JobPostingAnalysisRequest) => {
   const { data } = await privateClient.post<ApiResponse<JobPosting>>(
     '/job-postings',
     body,
@@ -33,4 +35,25 @@ export const deleteJobPosting = async (uuid: string) => {
     `/job-postings/${uuid}`,
   )
   return data.data
+}
+
+export const updateJobPostingCompanyName = async (
+  uuid: string,
+  body: UpdateJobPostingCompanyNameRequest,
+) => {
+  const { data } = await privateClient.patch<ApiResponse<JobPostingDetail>>(
+    `/job-postings/${uuid}`,
+    body,
+  )
+  return data.data
+}
+
+export const createJobPostingAnalysisEventSource = (uuid: string) => {
+  return new EventSource(`/api/job-postings/${uuid}/stream`)
+}
+
+export const parseJobPostingAnalysisEvent = (
+  event: MessageEvent<string>,
+): JobPostingAnalysisEvent => {
+  return JSON.parse(event.data)
 }

--- a/src/apis/job-postings/type.d.ts
+++ b/src/apis/job-postings/type.d.ts
@@ -25,8 +25,12 @@ export interface JobPostingListItem extends JobPosting {
   createdAt: string
 }
 
-export interface JobPostingAnalysisEvent {
-  timeout: number
+export interface JobPostingAnalysisDonePayload {
+  jobPostingUuid?: string
+}
+
+export interface JobPostingAnalysisErrorPayload {
+  message?: string
 }
 
 export interface JobPostingAnalysisRequest {

--- a/src/apis/job-postings/type.d.ts
+++ b/src/apis/job-postings/type.d.ts
@@ -1,9 +1,9 @@
-export type Status = 'PENDING' | 'ANALYZING' | 'DONE' | 'FAILED'
+export type JobPostingStatus = 'PENDING' | 'ANALYZING' | 'DONE' | 'FAILED'
 
 export interface JobPosting {
   uuid: string
   url: string
-  status: Status
+  status: JobPostingStatus
 }
 
 export interface JobPostingDetail extends JobPosting {
@@ -25,6 +25,14 @@ export interface JobPostingListItem extends JobPosting {
   createdAt: string
 }
 
-export interface CreateJobPostingRequest {
+export interface JobPostingAnalysisEvent {
+  timeout: number
+}
+
+export interface JobPostingAnalysisRequest {
   url: string
+}
+
+export interface UpdateJobPostingCompanyNameRequest {
+  companyName: string
 }

--- a/src/components/interview/JobPostingFormSection.tsx
+++ b/src/components/interview/JobPostingFormSection.tsx
@@ -1,16 +1,14 @@
 'use client'
 
-import { useState, useEffect, useRef, useCallback } from 'react'
+import { useState } from 'react'
 import { useRouter } from 'next/navigation'
 import Image from 'next/image'
-import { useMutation } from '@tanstack/react-query'
 import InputBox from '@/components/common/input/InputBox'
 import HelperText from '@/components/common/text/HelperText'
 import Button from '@/components/common/button/Button'
 import character3 from '@/assets/image/uug-character3-img.png'
 import { useModal } from '@/hooks/useModal'
-import { jobPostingAnalysisFlowApi } from '@/apis/job-postings'
-import type { JobPostingDetail } from '@/apis/job-postings/type'
+import { useJobPostingAnalysisFlow } from '@/components/interview/jobPostingAnalysis/useJobPostingAnalysisFlow'
 import AnalyzingPopup from '@/components/common/popup/AnalyzingPopup'
 import GeneratingPopup from '@/components/common/popup/GeneratingPopup'
 import CompanyNamePopup from '@/components/common/popup/CompanyNamePopup'
@@ -25,17 +23,6 @@ const JOB_URL_PATTERNS = [
 function isValidUrl(value: string): boolean {
   return JOB_URL_PATTERNS.some((pattern) => pattern.test(value))
 }
-
-const GENERATING_DELAY_MS = 2000
-
-type PopupState =
-  | 'analyzing'
-  | 'analysisFailed'
-  | 'companyName'
-  | 'generating'
-  | 'questionFailed'
-  | 'complete'
-  | null
 
 function CompletePopup({
   popupRef,
@@ -77,187 +64,20 @@ function CompletePopup({
 export default function JobPostingFormSection() {
   const router = useRouter()
   const [url, setUrl] = useState('')
-  const [popupState, setPopupState] = useState<PopupState>(null)
-  const [companyName, setCompanyName] = useState('')
-  const [jobPostingUuid, setJobPostingUuid] = useState<string | null>(null)
-  const [isPolling, setIsPolling] = useState(false)
-  const generatingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const {
+    popupState,
+    setPopupState,
+    companyName,
+    createJobPostingMutation,
+    handleClose,
+    handleCompanyNameSubmit,
+  } = useJobPostingAnalysisFlow()
 
   const { ref: popupRef } = useModal(popupState !== null)
 
   const urlError = url.trim().length > 0 && !isValidUrl(url)
   const urlValid = url.trim().length > 0 && isValidUrl(url)
   const isComplete = urlValid
-
-  const applyJobPostingDetail = useCallback((detail: JobPostingDetail) => {
-    if (detail.status === 'DONE') {
-      setIsPolling(false)
-      const name = detail.companyName || ''
-      if (name) {
-        setCompanyName(name)
-        setPopupState('generating')
-        generatingTimerRef.current = setTimeout(
-          () => setPopupState('complete'),
-          GENERATING_DELAY_MS,
-        )
-      } else {
-        setPopupState('companyName')
-      }
-    } else if (detail.status === 'FAILED') {
-      setIsPolling(false)
-      const reason = (detail.failureReason ?? '').toLowerCase()
-      if (reason.includes('question')) {
-        setPopupState('questionFailed')
-      } else {
-        setPopupState('analysisFailed')
-      }
-    }
-  }, [])
-
-  useEffect(() => {
-    if (!jobPostingUuid || !isPolling) return
-
-    const controller = new AbortController()
-    let streamFinished = false
-
-    const stopPolling = () => {
-      controller.abort()
-      setIsPolling(false)
-    }
-
-    void jobPostingAnalysisFlowApi.createJobPostingAnalysisEventSource(
-      jobPostingUuid,
-      {
-        signal: controller.signal,
-
-        async onmessage(ev) {
-          if (streamFinished) return
-
-          if (ev.event === 'JOB_POSTING_ANALYSIS_DONE') {
-            streamFinished = true
-            stopPolling()
-
-            try {
-              const { jobPostingUuid: uuidFromPayload } = JSON.parse(
-                ev.data,
-              ) as {
-                jobPostingUuid: string
-              }
-              const id = uuidFromPayload ?? jobPostingUuid
-              const detail = await jobPostingAnalysisFlowApi.getJobPosting(id)
-              applyJobPostingDetail(detail)
-            } catch {
-              setPopupState('analysisFailed')
-            }
-            return
-          }
-
-          if (ev.event === 'ERROR') {
-            streamFinished = true
-            stopPolling()
-
-            try {
-              const data = ev.data?.trim()
-                ? (JSON.parse(ev.data) as { message?: string })
-                : {}
-              const reason = (data.message ?? '').toLowerCase()
-              setPopupState(
-                reason.includes('question')
-                  ? 'questionFailed'
-                  : 'analysisFailed',
-              )
-            } catch {
-              setPopupState('analysisFailed')
-            }
-            return
-          }
-        },
-
-        onerror(error) {
-          if (streamFinished || controller.signal.aborted) return
-          console.error(error)
-        },
-      },
-    )
-
-    return () => {
-      controller.abort()
-    }
-  }, [jobPostingUuid, isPolling, applyJobPostingDetail])
-
-  useEffect(() => {
-    return () => {
-      if (generatingTimerRef.current) clearTimeout(generatingTimerRef.current)
-    }
-  }, [])
-
-  const createJobPostingMutation = useMutation({
-    mutationFn: jobPostingAnalysisFlowApi.createJobPosting,
-    onSuccess: async (data) => {
-      setJobPostingUuid(data.uuid)
-
-      if (data.status === 'DONE' || data.status === 'FAILED') {
-        try {
-          const detail = await jobPostingAnalysisFlowApi.getJobPosting(
-            data.uuid,
-          )
-          applyJobPostingDetail(detail)
-        } catch {
-          setIsPolling(false)
-          setPopupState('analysisFailed')
-        }
-        return
-      }
-
-      setIsPolling(true)
-    },
-    onError: () => {
-      setPopupState('analysisFailed')
-    },
-  })
-
-  const updateCompanyNameMutation = useMutation({
-    mutationFn: ({
-      uuid,
-      companyName,
-    }: {
-      uuid: string
-      companyName: string
-    }) =>
-      jobPostingAnalysisFlowApi.updateJobPostingCompanyName(uuid, {
-        companyName,
-      }),
-  })
-
-  function handleClose() {
-    setIsPolling(false)
-    if (generatingTimerRef.current) clearTimeout(generatingTimerRef.current)
-    setPopupState(null)
-    setJobPostingUuid(null)
-    setCompanyName('')
-  }
-
-  function handleCompanyNameSubmit(name: string) {
-    const trimmed = name.trim()
-    if (!jobPostingUuid || !trimmed) return
-
-    updateCompanyNameMutation.mutate(
-      { uuid: jobPostingUuid, companyName: trimmed },
-      {
-        onSuccess: () => {
-          setCompanyName(trimmed)
-          setPopupState('generating')
-          generatingTimerRef.current = setTimeout(
-            () => setPopupState('complete'),
-            GENERATING_DELAY_MS,
-          )
-        },
-        onError: () => {
-          setPopupState('analysisFailed')
-        },
-      },
-    )
-  }
 
   return (
     <section className="flex flex-col flex-1 min-h-0 gap-5 px-10 pt-6.5 pb-10">

--- a/src/components/interview/JobPostingFormSection.tsx
+++ b/src/components/interview/JobPostingFormSection.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect, useRef, useCallback } from 'react'
 import { useRouter } from 'next/navigation'
 import Image from 'next/image'
 import { useMutation, useQuery } from '@tanstack/react-query'
@@ -10,6 +10,7 @@ import Button from '@/components/common/button/Button'
 import character3 from '@/assets/image/uug-character3-img.png'
 import { useModal } from '@/hooks/useModal'
 import { createJobPosting, getJobPosting } from '@/apis/job-postings'
+import type { JobPostingDetail } from '@/apis/job-postings/type'
 import AnalyzingPopup from '@/components/common/popup/AnalyzingPopup'
 import GeneratingPopup from '@/components/common/popup/GeneratingPopup'
 import CompanyNamePopup from '@/components/common/popup/CompanyNamePopup'
@@ -96,12 +97,10 @@ export default function JobPostingFormSection() {
     refetchIntervalInBackground: true,
   })
 
-  useEffect(() => {
-    if (!jobPostingDetail || !isPolling) return
-
-    if (jobPostingDetail.status === 'DONE') {
+  const applyJobPostingDetail = useCallback((detail: JobPostingDetail) => {
+    if (detail.status === 'DONE') {
       setIsPolling(false)
-      const name = jobPostingDetail.companyName || ''
+      const name = detail.companyName || ''
       if (name) {
         setCompanyName(name)
         setPopupState('generating')
@@ -112,16 +111,27 @@ export default function JobPostingFormSection() {
       } else {
         setPopupState('companyName')
       }
-    } else if (jobPostingDetail.status === 'FAILED') {
+    } else if (detail.status === 'FAILED') {
       setIsPolling(false)
-      const reason = (jobPostingDetail.failureReason ?? '').toLowerCase()
+      const reason = (detail.failureReason ?? '').toLowerCase()
       if (reason.includes('question')) {
         setPopupState('questionFailed')
       } else {
         setPopupState('analysisFailed')
       }
     }
-  }, [jobPostingDetail, isPolling])
+  }, [])
+
+  useEffect(() => {
+    if (!jobPostingDetail || !isPolling) return
+    if (
+      jobPostingDetail.status !== 'DONE' &&
+      jobPostingDetail.status !== 'FAILED'
+    ) {
+      return
+    }
+    applyJobPostingDetail(jobPostingDetail)
+  }, [jobPostingDetail, isPolling, applyJobPostingDetail])
 
   useEffect(() => {
     return () => {
@@ -131,8 +141,20 @@ export default function JobPostingFormSection() {
 
   const createJobPostingMutation = useMutation({
     mutationFn: createJobPosting,
-    onSuccess: (data) => {
+    onSuccess: async (data) => {
       setJobPostingUuid(data.uuid)
+
+      if (data.status === 'DONE' || data.status === 'FAILED') {
+        try {
+          const detail = await getJobPosting(data.uuid)
+          applyJobPostingDetail(detail)
+        } catch {
+          setIsPolling(false)
+          setPopupState('analysisFailed')
+        }
+        return
+      }
+
       setIsPolling(true)
     },
     onError: () => {

--- a/src/components/interview/JobPostingFormSection.tsx
+++ b/src/components/interview/JobPostingFormSection.tsx
@@ -9,11 +9,7 @@ import HelperText from '@/components/common/text/HelperText'
 import Button from '@/components/common/button/Button'
 import character3 from '@/assets/image/uug-character3-img.png'
 import { useModal } from '@/hooks/useModal'
-import {
-  createJobPosting,
-  createJobPostingAnalysisEventSource,
-  getJobPosting,
-} from '@/apis/job-postings'
+import { jobPostingAnalysisFlowApi } from '@/apis/job-postings'
 import type { JobPostingDetail } from '@/apis/job-postings/type'
 import AnalyzingPopup from '@/components/common/popup/AnalyzingPopup'
 import GeneratingPopup from '@/components/common/popup/GeneratingPopup'
@@ -93,14 +89,6 @@ export default function JobPostingFormSection() {
   const urlValid = url.trim().length > 0 && isValidUrl(url)
   const isComplete = urlValid
 
-  // const { data: jobPostingDetail } = useQuery({
-  //   queryKey: ['job-posting', jobPostingUuid],
-  //   queryFn: ({ queryKey }) => getJobPosting(queryKey[1] as string),
-  //   enabled: !!jobPostingUuid && isPolling,
-  //   refetchInterval: isPolling ? 2000 : false,
-  //   refetchIntervalInBackground: true,
-  // })
-
   const applyJobPostingDetail = useCallback((detail: JobPostingDetail) => {
     if (detail.status === 'DONE') {
       setIsPolling(false)
@@ -137,53 +125,60 @@ export default function JobPostingFormSection() {
       setIsPolling(false)
     }
 
-    void createJobPostingAnalysisEventSource(jobPostingUuid, {
-      signal: controller.signal,
+    void jobPostingAnalysisFlowApi.createJobPostingAnalysisEventSource(
+      jobPostingUuid,
+      {
+        signal: controller.signal,
 
-      async onmessage(ev) {
-        if (streamFinished) return
+        async onmessage(ev) {
+          if (streamFinished) return
 
-        if (ev.event === 'JOB_POSTING_ANALYSIS_DONE') {
-          streamFinished = true
-          stopPolling()
+          if (ev.event === 'JOB_POSTING_ANALYSIS_DONE') {
+            streamFinished = true
+            stopPolling()
 
-          try {
-            const { jobPostingUuid: uuidFromPayload } = JSON.parse(ev.data) as {
-              jobPostingUuid: string
+            try {
+              const { jobPostingUuid: uuidFromPayload } = JSON.parse(
+                ev.data,
+              ) as {
+                jobPostingUuid: string
+              }
+              const id = uuidFromPayload ?? jobPostingUuid
+              const detail = await jobPostingAnalysisFlowApi.getJobPosting(id)
+              applyJobPostingDetail(detail)
+            } catch {
+              setPopupState('analysisFailed')
             }
-            const id = uuidFromPayload ?? jobPostingUuid
-            const detail = await getJobPosting(id)
-            applyJobPostingDetail(detail)
-          } catch {
-            setPopupState('analysisFailed')
+            return
           }
-          return
-        }
 
-        if (ev.event === 'ERROR') {
-          streamFinished = true
-          stopPolling()
+          if (ev.event === 'ERROR') {
+            streamFinished = true
+            stopPolling()
 
-          try {
-            const data = ev.data?.trim()
-              ? (JSON.parse(ev.data) as { message?: string })
-              : {}
-            const reason = (data.message ?? '').toLowerCase()
-            setPopupState(
-              reason.includes('question') ? 'questionFailed' : 'analysisFailed',
-            )
-          } catch {
-            setPopupState('analysisFailed')
+            try {
+              const data = ev.data?.trim()
+                ? (JSON.parse(ev.data) as { message?: string })
+                : {}
+              const reason = (data.message ?? '').toLowerCase()
+              setPopupState(
+                reason.includes('question')
+                  ? 'questionFailed'
+                  : 'analysisFailed',
+              )
+            } catch {
+              setPopupState('analysisFailed')
+            }
+            return
           }
-          return
-        }
-      },
+        },
 
-      onerror(error) {
-        if (streamFinished || controller.signal.aborted) return
-        console.error(error)
+        onerror(error) {
+          if (streamFinished || controller.signal.aborted) return
+          console.error(error)
+        },
       },
-    })
+    )
 
     return () => {
       controller.abort()
@@ -197,13 +192,15 @@ export default function JobPostingFormSection() {
   }, [])
 
   const createJobPostingMutation = useMutation({
-    mutationFn: createJobPosting,
+    mutationFn: jobPostingAnalysisFlowApi.createJobPosting,
     onSuccess: async (data) => {
       setJobPostingUuid(data.uuid)
 
       if (data.status === 'DONE' || data.status === 'FAILED') {
         try {
-          const detail = await getJobPosting(data.uuid)
+          const detail = await jobPostingAnalysisFlowApi.getJobPosting(
+            data.uuid,
+          )
           applyJobPostingDetail(detail)
         } catch {
           setIsPolling(false)
@@ -219,6 +216,19 @@ export default function JobPostingFormSection() {
     },
   })
 
+  const updateCompanyNameMutation = useMutation({
+    mutationFn: ({
+      uuid,
+      companyName,
+    }: {
+      uuid: string
+      companyName: string
+    }) =>
+      jobPostingAnalysisFlowApi.updateJobPostingCompanyName(uuid, {
+        companyName,
+      }),
+  })
+
   function handleClose() {
     setIsPolling(false)
     if (generatingTimerRef.current) clearTimeout(generatingTimerRef.current)
@@ -228,11 +238,24 @@ export default function JobPostingFormSection() {
   }
 
   function handleCompanyNameSubmit(name: string) {
-    setCompanyName(name)
-    setPopupState('generating')
-    generatingTimerRef.current = setTimeout(
-      () => setPopupState('complete'),
-      GENERATING_DELAY_MS,
+    const trimmed = name.trim()
+    if (!jobPostingUuid || !trimmed) return
+
+    updateCompanyNameMutation.mutate(
+      { uuid: jobPostingUuid, companyName: trimmed },
+      {
+        onSuccess: () => {
+          setCompanyName(trimmed)
+          setPopupState('generating')
+          generatingTimerRef.current = setTimeout(
+            () => setPopupState('complete'),
+            GENERATING_DELAY_MS,
+          )
+        },
+        onError: () => {
+          setPopupState('analysisFailed')
+        },
+      },
     )
   }
 

--- a/src/components/interview/JobPostingFormSection.tsx
+++ b/src/components/interview/JobPostingFormSection.tsx
@@ -130,6 +130,7 @@ export default function JobPostingFormSection() {
     if (!jobPostingUuid || !isPolling) return
 
     const controller = new AbortController()
+    let streamFinished = false
 
     const stopPolling = () => {
       controller.abort()
@@ -139,24 +140,48 @@ export default function JobPostingFormSection() {
     void createJobPostingAnalysisEventSource(jobPostingUuid, {
       signal: controller.signal,
 
-      async onmessage(event) {
-        if (!event.data?.trim()) return
+      async onmessage(ev) {
+        if (streamFinished) return
 
-        let payload: { timeout?: number }
+        if (ev.event === 'JOB_POSTING_ANALYSIS_DONE') {
+          streamFinished = true
+          stopPolling()
 
-        try {
-          payload = JSON.parse(event.data)
-        } catch {
+          try {
+            const { jobPostingUuid: uuidFromPayload } = JSON.parse(ev.data) as {
+              jobPostingUuid: string
+            }
+            const id = uuidFromPayload ?? jobPostingUuid
+            const detail = await getJobPosting(id)
+            applyJobPostingDetail(detail)
+          } catch {
+            setPopupState('analysisFailed')
+          }
           return
         }
-        if (payload.timeout !== 0) return
-        stopPolling()
-        try {
-          const detail = await getJobPosting(jobPostingUuid)
-          applyJobPostingDetail(detail)
-        } catch {
-          setPopupState('analysisFailed')
+
+        if (ev.event === 'ERROR') {
+          streamFinished = true
+          stopPolling()
+
+          try {
+            const data = ev.data?.trim()
+              ? (JSON.parse(ev.data) as { message?: string })
+              : {}
+            const reason = (data.message ?? '').toLowerCase()
+            setPopupState(
+              reason.includes('question') ? 'questionFailed' : 'analysisFailed',
+            )
+          } catch {
+            setPopupState('analysisFailed')
+          }
+          return
         }
+      },
+
+      onerror(error) {
+        if (streamFinished || controller.signal.aborted) return
+        console.error(error)
       },
     })
 

--- a/src/components/interview/JobPostingFormSection.tsx
+++ b/src/components/interview/JobPostingFormSection.tsx
@@ -136,45 +136,27 @@ export default function JobPostingFormSection() {
       setIsPolling(false)
     }
 
-    createJobPostingAnalysisEventSource(jobPostingUuid, {
+    void createJobPostingAnalysisEventSource(jobPostingUuid, {
       signal: controller.signal,
 
       async onmessage(event) {
-        const data = event.data ? JSON.parse(event.data) : {}
+        if (!event.data?.trim()) return
 
-        if (event.event === 'JOB_POSTING_ANALYSIS_DONE') {
-          stopPolling()
+        let payload: { timeout?: number }
 
-          try {
-            const detail = await getJobPosting(jobPostingUuid)
-            applyJobPostingDetail(detail)
-          } catch {
-            setPopupState('analysisFailed')
-          }
-
+        try {
+          payload = JSON.parse(event.data)
+        } catch {
           return
         }
-
-        if (event.event === 'ERROR') {
-          stopPolling()
-
-          const reason = (
-            data.failureReason ??
-            data.message ??
-            ''
-          ).toLowerCase()
-
-          setPopupState(
-            reason.includes('question') ? 'questionFailed' : 'analysisFailed',
-          )
-        }
-      },
-
-      onerror(error) {
+        if (payload.timeout !== 0) return
         stopPolling()
-        setPopupState('analysisFailed')
-
-        throw error
+        try {
+          const detail = await getJobPosting(jobPostingUuid)
+          applyJobPostingDetail(detail)
+        } catch {
+          setPopupState('analysisFailed')
+        }
       },
     })
 

--- a/src/components/interview/JobPostingFormSection.tsx
+++ b/src/components/interview/JobPostingFormSection.tsx
@@ -3,13 +3,17 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
 import { useRouter } from 'next/navigation'
 import Image from 'next/image'
-import { useMutation, useQuery } from '@tanstack/react-query'
+import { useMutation } from '@tanstack/react-query'
 import InputBox from '@/components/common/input/InputBox'
 import HelperText from '@/components/common/text/HelperText'
 import Button from '@/components/common/button/Button'
 import character3 from '@/assets/image/uug-character3-img.png'
 import { useModal } from '@/hooks/useModal'
-import { createJobPosting, getJobPosting } from '@/apis/job-postings'
+import {
+  createJobPosting,
+  createJobPostingAnalysisEventSource,
+  getJobPosting,
+} from '@/apis/job-postings'
 import type { JobPostingDetail } from '@/apis/job-postings/type'
 import AnalyzingPopup from '@/components/common/popup/AnalyzingPopup'
 import GeneratingPopup from '@/components/common/popup/GeneratingPopup'
@@ -89,13 +93,13 @@ export default function JobPostingFormSection() {
   const urlValid = url.trim().length > 0 && isValidUrl(url)
   const isComplete = urlValid
 
-  const { data: jobPostingDetail } = useQuery({
-    queryKey: ['job-posting', jobPostingUuid],
-    queryFn: ({ queryKey }) => getJobPosting(queryKey[1] as string),
-    enabled: !!jobPostingUuid && isPolling,
-    refetchInterval: isPolling ? 2000 : false,
-    refetchIntervalInBackground: true,
-  })
+  // const { data: jobPostingDetail } = useQuery({
+  //   queryKey: ['job-posting', jobPostingUuid],
+  //   queryFn: ({ queryKey }) => getJobPosting(queryKey[1] as string),
+  //   enabled: !!jobPostingUuid && isPolling,
+  //   refetchInterval: isPolling ? 2000 : false,
+  //   refetchIntervalInBackground: true,
+  // })
 
   const applyJobPostingDetail = useCallback((detail: JobPostingDetail) => {
     if (detail.status === 'DONE') {
@@ -123,15 +127,61 @@ export default function JobPostingFormSection() {
   }, [])
 
   useEffect(() => {
-    if (!jobPostingDetail || !isPolling) return
-    if (
-      jobPostingDetail.status !== 'DONE' &&
-      jobPostingDetail.status !== 'FAILED'
-    ) {
-      return
+    if (!jobPostingUuid || !isPolling) return
+
+    const controller = new AbortController()
+
+    const stopPolling = () => {
+      controller.abort()
+      setIsPolling(false)
     }
-    applyJobPostingDetail(jobPostingDetail)
-  }, [jobPostingDetail, isPolling, applyJobPostingDetail])
+
+    createJobPostingAnalysisEventSource(jobPostingUuid, {
+      signal: controller.signal,
+
+      async onmessage(event) {
+        const data = event.data ? JSON.parse(event.data) : {}
+
+        if (event.event === 'JOB_POSTING_ANALYSIS_DONE') {
+          stopPolling()
+
+          try {
+            const detail = await getJobPosting(jobPostingUuid)
+            applyJobPostingDetail(detail)
+          } catch {
+            setPopupState('analysisFailed')
+          }
+
+          return
+        }
+
+        if (event.event === 'ERROR') {
+          stopPolling()
+
+          const reason = (
+            data.failureReason ??
+            data.message ??
+            ''
+          ).toLowerCase()
+
+          setPopupState(
+            reason.includes('question') ? 'questionFailed' : 'analysisFailed',
+          )
+        }
+      },
+
+      onerror(error) {
+        stopPolling()
+        setPopupState('analysisFailed')
+
+        throw error
+      },
+    })
+
+    return () => {
+      controller.abort()
+    }
+  }, [jobPostingUuid, isPolling, applyJobPostingDetail])
 
   useEffect(() => {
     return () => {

--- a/src/components/interview/jobPostingAnalysis/sse.ts
+++ b/src/components/interview/jobPostingAnalysis/sse.ts
@@ -1,0 +1,23 @@
+export const SSE_EVENT_JOB_POSTING_ANALYSIS_DONE =
+  'JOB_POSTING_ANALYSIS_DONE' as const
+export const SSE_EVENT_ERROR = 'ERROR' as const
+
+export function parseJobPostingDonePayload(data: string): {
+  jobPostingUuid?: string
+} | null {
+  try {
+    return JSON.parse(data) as { jobPostingUuid?: string }
+  } catch {
+    return null
+  }
+}
+
+export function parseErrorPayload(data: string): { message?: string } {
+  const trimmed = data.trim()
+  if (!trimmed) return {}
+  try {
+    return JSON.parse(trimmed) as { message?: string }
+  } catch {
+    return {}
+  }
+}

--- a/src/components/interview/jobPostingAnalysis/sse.ts
+++ b/src/components/interview/jobPostingAnalysis/sse.ts
@@ -1,22 +1,29 @@
+import type {
+  JobPostingAnalysisDonePayload,
+  JobPostingAnalysisErrorPayload,
+} from '@/apis/job-postings/type'
+
 export const SSE_EVENT_JOB_POSTING_ANALYSIS_DONE =
   'JOB_POSTING_ANALYSIS_DONE' as const
 export const SSE_EVENT_ERROR = 'ERROR' as const
 
-export function parseJobPostingDonePayload(data: string): {
-  jobPostingUuid?: string
-} | null {
+export function parseJobPostingDonePayload(
+  data: string,
+): JobPostingAnalysisDonePayload | null {
   try {
-    return JSON.parse(data) as { jobPostingUuid?: string }
+    return JSON.parse(data) as JobPostingAnalysisDonePayload
   } catch {
     return null
   }
 }
 
-export function parseErrorPayload(data: string): { message?: string } {
+export function parseErrorPayload(
+  data: string,
+): JobPostingAnalysisErrorPayload {
   const trimmed = data.trim()
   if (!trimmed) return {}
   try {
-    return JSON.parse(trimmed) as { message?: string }
+    return JSON.parse(trimmed) as JobPostingAnalysisErrorPayload
   } catch {
     return {}
   }

--- a/src/components/interview/jobPostingAnalysis/useJobPostingAnalysisFlow.ts
+++ b/src/components/interview/jobPostingAnalysis/useJobPostingAnalysisFlow.ts
@@ -1,0 +1,205 @@
+'use client'
+
+import { useState, useEffect, useRef, useCallback } from 'react'
+import { useMutation } from '@tanstack/react-query'
+import { jobPostingAnalysisFlowApi } from '@/apis/job-postings'
+import type { JobPostingDetail } from '@/apis/job-postings/type'
+import {
+  SSE_EVENT_ERROR,
+  SSE_EVENT_JOB_POSTING_ANALYSIS_DONE,
+  parseErrorPayload,
+  parseJobPostingDonePayload,
+} from './sse'
+
+const GENERATING_DELAY_MS = 2000
+
+export type JobPostingAnalysisPopupState =
+  | 'analyzing'
+  | 'analysisFailed'
+  | 'companyName'
+  | 'generating'
+  | 'questionFailed'
+  | 'complete'
+  | null
+
+export function useJobPostingAnalysisFlow() {
+  const [popupState, setPopupState] =
+    useState<JobPostingAnalysisPopupState>(null)
+  const [companyName, setCompanyName] = useState('')
+  const [jobPostingUuid, setJobPostingUuid] = useState<string | null>(null)
+  const [isPolling, setIsPolling] = useState(false)
+  const generatingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const applyJobPostingDetail = useCallback((detail: JobPostingDetail) => {
+    if (detail.status === 'DONE') {
+      setIsPolling(false)
+      const name = detail.companyName || ''
+      if (name) {
+        setCompanyName(name)
+        setPopupState('generating')
+        generatingTimerRef.current = setTimeout(
+          () => setPopupState('complete'),
+          GENERATING_DELAY_MS,
+        )
+      } else {
+        setPopupState('companyName')
+      }
+    } else if (detail.status === 'FAILED') {
+      setIsPolling(false)
+      const reason = (detail.failureReason ?? '').toLowerCase()
+      if (reason.includes('question')) {
+        setPopupState('questionFailed')
+      } else {
+        setPopupState('analysisFailed')
+      }
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!jobPostingUuid || !isPolling) return
+
+    const controller = new AbortController()
+    let streamFinished = false
+
+    const stopPolling = () => {
+      controller.abort()
+      setIsPolling(false)
+    }
+
+    void jobPostingAnalysisFlowApi.createJobPostingAnalysisEventSource(
+      jobPostingUuid,
+      {
+        signal: controller.signal,
+
+        async onmessage(ev) {
+          if (streamFinished) return
+
+          if (ev.event === SSE_EVENT_JOB_POSTING_ANALYSIS_DONE) {
+            streamFinished = true
+            stopPolling()
+
+            try {
+              const parsed = parseJobPostingDonePayload(ev.data)
+              if (!parsed) {
+                setPopupState('analysisFailed')
+                return
+              }
+              const id = parsed.jobPostingUuid ?? jobPostingUuid
+              const detail = await jobPostingAnalysisFlowApi.getJobPosting(id)
+              applyJobPostingDetail(detail)
+            } catch {
+              setPopupState('analysisFailed')
+            }
+            return
+          }
+
+          if (ev.event === SSE_EVENT_ERROR) {
+            streamFinished = true
+            stopPolling()
+
+            const data = parseErrorPayload(ev.data ?? '')
+            const reason = (data.message ?? '').toLowerCase()
+            setPopupState(
+              reason.includes('question')
+                ? 'questionFailed'
+                : 'analysisFailed',
+            )
+            return
+          }
+        },
+
+        onerror(error) {
+          if (streamFinished || controller.signal.aborted) return
+          console.error(error)
+        },
+      },
+    )
+
+    return () => {
+      controller.abort()
+    }
+  }, [jobPostingUuid, isPolling, applyJobPostingDetail])
+
+  useEffect(() => {
+    return () => {
+      if (generatingTimerRef.current) clearTimeout(generatingTimerRef.current)
+    }
+  }, [])
+
+  const createJobPostingMutation = useMutation({
+    mutationFn: jobPostingAnalysisFlowApi.createJobPosting,
+    onSuccess: async (data) => {
+      setJobPostingUuid(data.uuid)
+
+      if (data.status === 'DONE' || data.status === 'FAILED') {
+        try {
+          const detail = await jobPostingAnalysisFlowApi.getJobPosting(
+            data.uuid,
+          )
+          applyJobPostingDetail(detail)
+        } catch {
+          setIsPolling(false)
+          setPopupState('analysisFailed')
+        }
+        return
+      }
+
+      setIsPolling(true)
+    },
+    onError: () => {
+      setPopupState('analysisFailed')
+    },
+  })
+
+  const updateCompanyNameMutation = useMutation({
+    mutationFn: ({
+      uuid,
+      companyName: nextName,
+    }: {
+      uuid: string
+      companyName: string
+    }) =>
+      jobPostingAnalysisFlowApi.updateJobPostingCompanyName(uuid, {
+        companyName: nextName,
+      }),
+  })
+
+  function handleClose() {
+    setIsPolling(false)
+    if (generatingTimerRef.current) clearTimeout(generatingTimerRef.current)
+    setPopupState(null)
+    setJobPostingUuid(null)
+    setCompanyName('')
+  }
+
+  function handleCompanyNameSubmit(name: string) {
+    const trimmed = name.trim()
+    if (!jobPostingUuid || !trimmed) return
+
+    updateCompanyNameMutation.mutate(
+      { uuid: jobPostingUuid, companyName: trimmed },
+      {
+        onSuccess: () => {
+          setCompanyName(trimmed)
+          setPopupState('generating')
+          generatingTimerRef.current = setTimeout(
+            () => setPopupState('complete'),
+            GENERATING_DELAY_MS,
+          )
+        },
+        onError: () => {
+          setPopupState('analysisFailed')
+        },
+      },
+    )
+  }
+
+  return {
+    popupState,
+    setPopupState,
+    companyName,
+    createJobPostingMutation,
+    handleClose,
+    handleCompanyNameSubmit,
+  }
+}


### PR DESCRIPTION
## ✨ 작업 내용

> 작업한 내용에 대한 설명을 적어주세요

- Job postings API: 생성·상세 조회·SSE 스트림(fetch-event-source)과 회사명 PATCH를 jobPostingAnalysisFlowApi 으로 그룹화했습니다.
- SSE: 인증 헤더가 필요한 점을 고려하여 Native EventSource 대신 `@microsoft/fetch-event-source` 사용하였습니다.
- JOB_POSTING_ANALYSIS_DONE / ERROR 이벤트 분기 및 완료 후 플래그를 사용하여 중복 onmessage 방지하였습니다.
- 분석 완료 UX: DONE인데 회사명이 비워진 경우일 때 회사명 팝업 → `updateJobPostingCompanyName PATCH` 후 기존과 같이 generating → complete 흐름을 적용하였습니다.
- 즉시 종료 응답: POST 직후 이미 DONE/FAILED인 경우 SSE 없이 상세 조회로 처리하였습니다.
- 화면 코드를 sse 헬퍼 + useJobPostingAnalysisFlow 훅으로 나누었습니다.

## 🧩 백그라운드

> 작업이 필요했던 문제 상황을 적어주세요


## 📸 스크린샷(선택)

> 스크린샷이 필요한 작업이면 스크린샷을 첨부해주세요

## ✅ 테스트

- [x] 유효한 공고 URL 제출 → 분석 중 팝업 → SSE 완료 후 정상 완료 플로우
- [x] SSE ERROR / 분석 실패 시 실패 팝업 노출 확인

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

> 참고할 사항이 있다면 적어주세요
