### PR TITLE
[11-312] 면접 일정 및 커리큘럼 API 연동

### DIFF
--- a/src/apis/schedules/index.tsx
+++ b/src/apis/schedules/index.tsx
@@ -15,11 +15,14 @@ export const createInterviewSchedule = async (body: CreateScheduleRequest) => {
   return data.data
 }
 
-export const getInterviewScheduleList = async () => {
-  const { data } =
-    await privateClient.get<ApiResponse<GetScheduleListResponse>>('/schedules')
-  return data.data
-}
+export const getInterviewScheduleList =
+  async (): Promise<GetScheduleListResponse> => {
+    const { data } =
+      await privateClient.get<ApiResponse<GetScheduleListResponse>>(
+        '/schedules',
+      )
+    return data.data
+  }
 
 export const getInterviewSchedule = async (scheduleUuid: string) => {
   const { data } = await privateClient.get<ApiResponse<ScheduleDetail>>(

--- a/src/apis/schedules/index.tsx
+++ b/src/apis/schedules/index.tsx
@@ -1,0 +1,48 @@
+import { privateClient } from '@/apis/common/privateClient'
+import { ApiResponse } from '../common/type'
+import type {
+  ScheduleDetail,
+  CreateScheduleRequest,
+  UpdateScheduleRequest,
+  GetScheduleListResponse,
+} from '@/apis/schedules/type'
+
+export const createInterviewSchedule = async (body: CreateScheduleRequest) => {
+  const { data } = await privateClient.post<ApiResponse<ScheduleDetail>>(
+    '/api/schedules',
+    body,
+  )
+  return data.data
+}
+
+export const getInterviewScheduleList = async () => {
+  const { data } =
+    await privateClient.get<ApiResponse<GetScheduleListResponse>>(
+      '/api/schedules',
+    )
+  return data.data
+}
+
+export const getInterviewSchedule = async (scheduleUuid: string) => {
+  const { data } = await privateClient.get<ApiResponse<ScheduleDetail>>(
+    `/api/schedules/${scheduleUuid}`,
+  )
+  return data.data
+}
+
+export const updateInterviewSchedule = async (
+  scheduleUuid: string,
+  body: UpdateScheduleRequest,
+) => {
+  const { data } = await privateClient.put<ApiResponse<ScheduleDetail>>(
+    `/api/schedules/${scheduleUuid}`,
+  )
+  return data.data
+}
+
+export const deleteInterviewSchedule = async (scheduleUuid: string) => {
+  const { data } = await privateClient.delete<ApiResponse<string>>(
+    `/api/schedules/${scheduleUuid}`,
+  )
+  return data.data
+}

--- a/src/apis/schedules/index.tsx
+++ b/src/apis/schedules/index.tsx
@@ -46,3 +46,11 @@ export const deleteInterviewSchedule = async (scheduleUuid: string) => {
   )
   return data.data
 }
+
+export const scheduleApi = {
+  createInterviewSchedule,
+  getInterviewScheduleList,
+  getInterviewSchedule,
+  updateInterviewSchedule,
+  deleteInterviewSchedule,
+}

--- a/src/apis/schedules/index.tsx
+++ b/src/apis/schedules/index.tsx
@@ -48,11 +48,3 @@ export const deleteInterviewSchedule = async (scheduleUuid: string) => {
   )
   return data.data
 }
-
-export const scheduleApi = {
-  createInterviewSchedule,
-  getInterviewScheduleList,
-  getInterviewSchedule,
-  updateInterviewSchedule,
-  deleteInterviewSchedule,
-}

--- a/src/apis/schedules/index.tsx
+++ b/src/apis/schedules/index.tsx
@@ -9,7 +9,7 @@ import type {
 
 export const createInterviewSchedule = async (body: CreateScheduleRequest) => {
   const { data } = await privateClient.post<ApiResponse<ScheduleDetail>>(
-    '/api/schedules',
+    '/schedules',
     body,
   )
   return data.data
@@ -17,15 +17,13 @@ export const createInterviewSchedule = async (body: CreateScheduleRequest) => {
 
 export const getInterviewScheduleList = async () => {
   const { data } =
-    await privateClient.get<ApiResponse<GetScheduleListResponse>>(
-      '/api/schedules',
-    )
+    await privateClient.get<ApiResponse<GetScheduleListResponse>>('/schedules')
   return data.data
 }
 
 export const getInterviewSchedule = async (scheduleUuid: string) => {
   const { data } = await privateClient.get<ApiResponse<ScheduleDetail>>(
-    `/api/schedules/${scheduleUuid}`,
+    `/schedules/${scheduleUuid}`,
   )
   return data.data
 }
@@ -35,14 +33,15 @@ export const updateInterviewSchedule = async (
   body: UpdateScheduleRequest,
 ) => {
   const { data } = await privateClient.put<ApiResponse<ScheduleDetail>>(
-    `/api/schedules/${scheduleUuid}`,
+    `/schedules/${scheduleUuid}`,
+    body,
   )
   return data.data
 }
 
 export const deleteInterviewSchedule = async (scheduleUuid: string) => {
   const { data } = await privateClient.delete<ApiResponse<string>>(
-    `/api/schedules/${scheduleUuid}`,
+    `/schedules/${scheduleUuid}`,
   )
   return data.data
 }

--- a/src/apis/schedules/type.d.ts
+++ b/src/apis/schedules/type.d.ts
@@ -1,0 +1,26 @@
+export interface Curriculum {
+  uuid: string
+  jobPostingUuid: string
+  content: string
+  scheduledDate: string
+  isPast: boolean
+}
+
+export interface Schedule {
+  scheduleUuid: string
+  companyName: string
+  interviewDate: string
+}
+
+export interface ScheduleDetail extends Schedule {
+  curriculums: Curriculum[]
+}
+
+export interface CreateScheduleRequest {
+  companyName: string
+  interviewDate: string
+}
+
+export type UpdateScheduleRequest = CreateScheduleRequest
+
+export type GetScheduleListResponse = Schedule[]

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,6 +7,7 @@ import { homeMockData, emptyHomeMockData } from '@/mocks/homeMockData'
 export default function Home() {
   const data = homeMockData
   //const data = emptyHomeMockData
+
   return (
     <main className="h-screen overflow-hidden flex flex-col">
       <Header />
@@ -27,7 +28,7 @@ export default function Home() {
           </section>
 
           <div className="flex-shrink-0 mt-[clamp(8px,2vw,24px)] mb-[clamp(8px,2vw,24px)]">
-            <InterviewPlanSection data={data.interviewPlans} />
+            <InterviewPlanSection />
           </div>
         </div>
       </div>

--- a/src/app/ranking/page.tsx
+++ b/src/app/ranking/page.tsx
@@ -1,7 +1,7 @@
 import Header from '@/components/common/header/Header'
 import RankingCard from '@/components/ranking/RankingCard'
 import { MY_RANK, rankingList } from '@/mock/ranking'
-import { formatDateKo } from '@/utils/formatDate'
+import { formatDateKo } from '@/utils/date'
 
 export default function RankingPage() {
   const myData = rankingList.find((item) => item.rank === MY_RANK)
@@ -13,14 +13,14 @@ export default function RankingPage() {
         <section className="p-8">
           <div className="h1 mb-4">랭킹을 확인해보세요</div>
           <div className="p2 mb-2">나의 순위</div>
-          {myData && (
-            <RankingCard {...myData} variant="primary" size="lg" />
-          )}
+          {myData && <RankingCard {...myData} variant="primary" size="lg" />}
         </section>
         <div className="flex flex-col px-10">
           <div className="flex items-center gap-2 py-4">
             <span className="p2 text-gray-1">전체 유저 순위</span>
-            <span className="p4 text-gray-3">{formatDateKo()} 기준</span>
+            <span className="p4 text-gray-3">
+              {formatDateKo(new Date())} 기준
+            </span>
           </div>
           <section className="bg-secondary rounded-t-2xl">
             <div className="flex flex-col gap-4 p-8">

--- a/src/components/home/interviewPlan/InterviewPlanCurriculumColumn.tsx
+++ b/src/components/home/interviewPlan/InterviewPlanCurriculumColumn.tsx
@@ -1,9 +1,7 @@
 'use client'
 
-import { useState } from 'react'
-import { useQuery } from '@tanstack/react-query'
-import { getInterviewSchedule } from '@/apis/schedules'
 import type { ScheduleDetail } from '@/apis/schedules/type'
+import { formatMonthDay } from '@/utils/date'
 
 type InterviewPlanCurriculumColumnProps = {
   selectedScheduleDetail?: ScheduleDetail
@@ -39,7 +37,7 @@ export default function InterviewPlanCurriculumColumn({
                     {item.content}
                   </span>
                   <span className="shrink-0 p4 text-gray-3">
-                    {item.scheduledDate}
+                    {formatMonthDay(item.scheduledDate)}
                   </span>
                 </div>
               </div>

--- a/src/components/home/interviewPlan/InterviewPlanCurriculumColumn.tsx
+++ b/src/components/home/interviewPlan/InterviewPlanCurriculumColumn.tsx
@@ -1,16 +1,20 @@
 'use client'
 
-import type { InterviewPlanItem } from '@/types/interviewPlan'
+import { useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { getInterviewSchedule } from '@/apis/schedules'
+import type { ScheduleDetail } from '@/apis/schedules/type'
 
 type InterviewPlanCurriculumColumnProps = {
-  isEmpty: boolean
-  selectedPlan: InterviewPlanItem | null
+  selectedScheduleDetail?: ScheduleDetail
 }
 
 export default function InterviewPlanCurriculumColumn({
-  isEmpty,
-  selectedPlan,
+  selectedScheduleDetail,
 }: InterviewPlanCurriculumColumnProps) {
+  const curriculums = selectedScheduleDetail?.curriculums ?? []
+  const isEmpty = curriculums.length === 0
+
   return (
     <div className="flex flex-[1.3] flex-col ">
       <h3 className="mb-4 p2 text-text-primary">면접 커리큘럼</h3>
@@ -27,14 +31,16 @@ export default function InterviewPlanCurriculumColumn({
       ) : (
         <div className="max-h-[248px] flex-1 rounded-lg border border-primary bg-white px-6.5 py-6.5">
           <div className="space-y-4">
-            {selectedPlan?.curriculum.slice(0, 5).map((item) => (
-              <div key={item.id} className="flex items-start gap-4">
+            {curriculums.slice(0, 5).map((item) => (
+              <div key={item.uuid} className="flex items-start gap-4">
                 <span className="mt-2 inline-block h-1.5 w-1.5 rounded-full bg-[#977AFF]" />
                 <div className="flex min-w-0 flex-1 items-center justify-between gap-4">
                   <span className="truncate p3 text-text-primary">
-                    {item.title}
+                    {item.content}
                   </span>
-                  <span className="shrink-0 p4 text-gray-3">{item.date}</span>
+                  <span className="shrink-0 p4 text-gray-3">
+                    {item.scheduledDate}
+                  </span>
                 </div>
               </div>
             ))}

--- a/src/components/home/interviewPlan/InterviewPlanCurriculumColumn.tsx
+++ b/src/components/home/interviewPlan/InterviewPlanCurriculumColumn.tsx
@@ -31,12 +31,29 @@ export default function InterviewPlanCurriculumColumn({
           <div className="space-y-4">
             {curriculums.slice(0, 5).map((item) => (
               <div key={item.uuid} className="flex items-start gap-4">
-                <span className="mt-2 inline-block h-1.5 w-1.5 rounded-full bg-[#977AFF]" />
+                <span
+                  className={[
+                    'mt-2 inline-block h-1.5 w-1.5 rounded-full',
+                    item.isPast ? 'bg-[#C0AFFF]' : 'bg-[#977AFF]',
+                  ].join(' ')}
+                />
+
                 <div className="flex min-w-0 flex-1 items-center justify-between gap-4">
-                  <span className="truncate p3 text-text-primary">
+                  <span
+                    className={[
+                      'p3',
+                      item.isPast ? 'text-gray-4' : 'text-text-primary',
+                    ].join(' ')}
+                  >
                     {item.content}
                   </span>
-                  <span className="shrink-0 p4 text-gray-3">
+
+                  <span
+                    className={[
+                      'shrink-0 p4',
+                      item.isPast ? 'text-gray-4' : 'text-gray-3',
+                    ].join(' ')}
+                  >
                     {formatMonthDay(item.scheduledDate)}
                   </span>
                 </div>

--- a/src/components/home/interviewPlan/InterviewPlanScheduleColumn.tsx
+++ b/src/components/home/interviewPlan/InterviewPlanScheduleColumn.tsx
@@ -2,23 +2,22 @@
 
 import { IconPlus } from '@tabler/icons-react'
 import { useQuery } from '@tanstack/react-query'
-import { scheduleApi } from '@/apis/schedules'
+import { getInterviewScheduleList } from '@/apis/schedules'
 import InterviewPlanDotsTrigger from '@/components/home/interviewPlan/InterviewPlanDotsTrigger'
 import { EMPTY_INTERVIEW_PLAN_ROWS } from '@/constants/interviewPlanEmptyRows'
-import type { InterviewPlanItem } from '@/types/interviewPlan'
 
 type InterviewPlanScheduleColumnProps = {
-  data: readonly InterviewPlanItem[]
-  isEmpty: boolean
+  selectedScheduleUuid: string | null
   onToggleMenu: (key: string, el: HTMLElement) => void
   onOpenAddSchedule: () => void
+  onSelectSchedule: (scheduleUuid: string) => void
 }
 
 export default function InterviewPlanScheduleColumn({
-  data,
-  isEmpty,
+  selectedScheduleUuid,
   onToggleMenu,
   onOpenAddSchedule,
+  onSelectSchedule,
 }: InterviewPlanScheduleColumnProps) {
   const {
     data: schedules,
@@ -26,7 +25,7 @@ export default function InterviewPlanScheduleColumn({
     error,
   } = useQuery({
     queryKey: ['schedules'],
-    queryFn: scheduleApi.getInterviewScheduleList,
+    queryFn: getInterviewScheduleList,
   })
 
   const scheduleList = schedules ?? []
@@ -75,7 +74,13 @@ export default function InterviewPlanScheduleColumn({
             <div
               key={schedule.scheduleUuid}
               data-interview-plan-row
-              className="flex h-14 items-center justify-between rounded-lg border border-gray-5 bg-white px-5 py-3 gap-3"
+              onClick={() => onSelectSchedule(schedule.scheduleUuid)}
+              className={[
+                'flex h-14 items-center justify-between rounded-lg border bg-white px-5 py-3 gap-3 cursor-pointer',
+                selectedScheduleUuid === schedule.scheduleUuid
+                  ? 'border-primary'
+                  : 'border-gray-5',
+              ].join(' ')}
             >
               <div className="flex items-center gap-4 overflow-hidden min-w-0 flex-1">
                 <span className="h4 text-primary shrink-0">D-day</span>
@@ -89,7 +94,7 @@ export default function InterviewPlanScheduleColumn({
                 <span className="p4 text-gray-3">{schedule.interviewDate}</span>
 
                 <InterviewPlanDotsTrigger
-                  menuKey={`plan-${schedule.scheduleUuid}`}
+                  menuKey={`${schedule.scheduleUuid}`}
                   onToggleMenu={onToggleMenu}
                 />
               </div>

--- a/src/components/home/interviewPlan/InterviewPlanScheduleColumn.tsx
+++ b/src/components/home/interviewPlan/InterviewPlanScheduleColumn.tsx
@@ -1,6 +1,8 @@
 'use client'
 
 import { IconPlus } from '@tabler/icons-react'
+import { useQuery } from '@tanstack/react-query'
+import { scheduleApi } from '@/apis/schedules'
 import InterviewPlanDotsTrigger from '@/components/home/interviewPlan/InterviewPlanDotsTrigger'
 import { EMPTY_INTERVIEW_PLAN_ROWS } from '@/constants/interviewPlanEmptyRows'
 import type { InterviewPlanItem } from '@/types/interviewPlan'
@@ -18,6 +20,18 @@ export default function InterviewPlanScheduleColumn({
   onToggleMenu,
   onOpenAddSchedule,
 }: InterviewPlanScheduleColumnProps) {
+  const {
+    data: schedules,
+    isLoading,
+    error,
+  } = useQuery({
+    queryKey: ['schedules'],
+    queryFn: scheduleApi.getInterviewScheduleList,
+  })
+
+  const scheduleList = schedules ?? []
+  const isScheduleEmpty = scheduleList.length === 0
+
   return (
     <div className="flex-1 flex flex-col min-h-0">
       <div className="mb-4 flex items-center gap-2">
@@ -32,7 +46,7 @@ export default function InterviewPlanScheduleColumn({
         </button>
       </div>
 
-      {isEmpty ? (
+      {isScheduleEmpty ? (
         <div className="space-y-3.5">
           {EMPTY_INTERVIEW_PLAN_ROWS.map((row) => (
             <div
@@ -57,27 +71,25 @@ export default function InterviewPlanScheduleColumn({
         </div>
       ) : (
         <div className="max-h-[248px] overflow-y-auto space-y-4 pr-2">
-          {data.map((plan) => (
+          {scheduleList.map((schedule) => (
             <div
-              key={plan.id}
+              key={schedule.scheduleUuid}
               data-interview-plan-row
-              className={[
-                'flex h-14 items-center justify-between rounded-lg border bg-white px-5 py-3 gap-3',
-                plan.isSelected ? 'border-primary' : 'border-gray-5',
-              ].join(' ')}
+              className="flex h-14 items-center justify-between rounded-lg border border-gray-5 bg-white px-5 py-3 gap-3"
             >
               <div className="flex items-center gap-4 overflow-hidden min-w-0 flex-1">
-                <span className="h4 text-primary shrink-0">{plan.dDay}</span>
+                <span className="h4 text-primary shrink-0">D-day</span>
 
                 <span className="shrink-0 p2 text-text-primary truncate">
-                  {plan.companyName} {plan.title}
+                  {schedule.companyName}
                 </span>
               </div>
 
               <div className="flex items-center gap-3 shrink-0">
-                <span className="p4 text-gray-3">{plan.date}</span>
+                <span className="p4 text-gray-3">{schedule.interviewDate}</span>
+
                 <InterviewPlanDotsTrigger
-                  menuKey={`plan-${plan.id}`}
+                  menuKey={`plan-${schedule.scheduleUuid}`}
                   onToggleMenu={onToggleMenu}
                 />
               </div>

--- a/src/components/home/interviewPlan/InterviewPlanScheduleColumn.tsx
+++ b/src/components/home/interviewPlan/InterviewPlanScheduleColumn.tsx
@@ -2,6 +2,7 @@
 
 import { IconPlus } from '@tabler/icons-react'
 import { useQuery } from '@tanstack/react-query'
+import { formatMonthDay, getDDay } from '@/utils/date'
 import { getInterviewScheduleList } from '@/apis/schedules'
 import InterviewPlanDotsTrigger from '@/components/home/interviewPlan/InterviewPlanDotsTrigger'
 import { EMPTY_INTERVIEW_PLAN_ROWS } from '@/constants/interviewPlanEmptyRows'
@@ -83,7 +84,9 @@ export default function InterviewPlanScheduleColumn({
               ].join(' ')}
             >
               <div className="flex items-center gap-4 overflow-hidden min-w-0 flex-1">
-                <span className="h4 text-primary shrink-0">D-day</span>
+                <span className="h4 text-primary shrink-0">
+                  {getDDay(schedule.interviewDate)}
+                </span>
 
                 <span className="shrink-0 p2 text-text-primary truncate">
                   {schedule.companyName}
@@ -91,7 +94,9 @@ export default function InterviewPlanScheduleColumn({
               </div>
 
               <div className="flex items-center gap-3 shrink-0">
-                <span className="p4 text-gray-3">{schedule.interviewDate}</span>
+                <span className="p4 text-gray-3">
+                  {formatMonthDay(schedule.interviewDate)}
+                </span>
 
                 <InterviewPlanDotsTrigger
                   menuKey={`${schedule.scheduleUuid}`}

--- a/src/components/home/interviewPlan/InterviewPlanSection.tsx
+++ b/src/components/home/interviewPlan/InterviewPlanSection.tsx
@@ -24,6 +24,10 @@ export default function InterviewPlanSection({
     useState<InterviewSchedulePopupMode>('create')
   const [actionsMenu, setActionsMenu] =
     useState<InterviewPlanMenuPosition | null>(null)
+  const [editingScheduleUuid, setEditingScheduleUuid] = useState<string | null>(
+    null,
+  )
+
   const isEmpty = data.length === 0
 
   const selectedPlan = data.find((plan) => plan.isSelected) ?? data[0] ?? null
@@ -37,12 +41,13 @@ export default function InterviewPlanSection({
     })
   }, [])
 
-  const handleEdit = useCallback((_key: string) => {
+  const handleEdit = useCallback((scheduleUuid: string) => {
+    setEditingScheduleUuid(scheduleUuid)
     setSchedulePopupMode('edit')
     setIsSchedulePopupOpen(true)
   }, [])
 
-  const handleDelete = useCallback((_key: string) => {
+  const handleDelete = useCallback((scheduleUuid: string) => {
     // TODO: 삭제 확인 및 API 연동
   }, [])
 
@@ -51,6 +56,7 @@ export default function InterviewPlanSection({
   }, [])
 
   const openCreateSchedulePopup = useCallback(() => {
+    setEditingScheduleUuid(null)
     setSchedulePopupMode('create')
     setIsSchedulePopupOpen(true)
   }, [])
@@ -84,6 +90,7 @@ export default function InterviewPlanSection({
       {isSchedulePopupOpen && (
         <InterviewScheduleRegisterPopup
           mode={schedulePopupMode}
+          scheduleUuid={editingScheduleUuid ?? undefined}
           onClose={closeSchedulePopup}
         />
       )}

--- a/src/components/home/interviewPlan/InterviewPlanSection.tsx
+++ b/src/components/home/interviewPlan/InterviewPlanSection.tsx
@@ -1,6 +1,8 @@
 'use client'
 
 import { useCallback, useState } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { deleteInterviewSchedule, getInterviewSchedule } from '@/apis/schedules'
 import InterviewPlanActionsMenuPortal, {
   computeMenuPosition,
   type InterviewPlanMenuPosition,
@@ -19,6 +21,9 @@ type InterviewPlanSectionProps = {
 export default function InterviewPlanSection({
   data,
 }: InterviewPlanSectionProps) {
+  const [selectedScheduleUuid, setSelectedScheduleUuid] = useState<
+    string | null
+  >(null)
   const [isSchedulePopupOpen, setIsSchedulePopupOpen] = useState(false)
   const [schedulePopupMode, setSchedulePopupMode] =
     useState<InterviewSchedulePopupMode>('create')
@@ -31,6 +36,27 @@ export default function InterviewPlanSection({
   const isEmpty = data.length === 0
 
   const selectedPlan = data.find((plan) => plan.isSelected) ?? data[0] ?? null
+
+  const queryClient = useQueryClient()
+
+  const { data: selectedScheduleDetail } = useQuery({
+    queryKey: ['schedule', selectedScheduleUuid],
+    queryFn: () => getInterviewSchedule(selectedScheduleUuid!),
+    enabled: !!selectedScheduleUuid,
+  })
+
+  const deleteInterviewScheduleMutation = useMutation({
+    mutationFn: deleteInterviewSchedule,
+
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['schedules'] })
+      setActionsMenu(null)
+    },
+
+    onError: (error) => {
+      console.error('삭제 실패', error)
+    },
+  })
 
   const toggleActionsMenu = useCallback((key: string, el: HTMLElement) => {
     setActionsMenu((prev) => {
@@ -47,9 +73,12 @@ export default function InterviewPlanSection({
     setIsSchedulePopupOpen(true)
   }, [])
 
-  const handleDelete = useCallback((scheduleUuid: string) => {
-    // TODO: 삭제 확인 및 API 연동
-  }, [])
+  const handleDelete = useCallback(
+    (scheduleUuid: string) => {
+      deleteInterviewScheduleMutation.mutate(scheduleUuid)
+    },
+    [deleteInterviewScheduleMutation],
+  )
 
   const closeActionsMenu = useCallback(() => {
     setActionsMenu(null)
@@ -69,14 +98,13 @@ export default function InterviewPlanSection({
     <section className="min-h-[clamp(320px,36vh,420px)] rounded-2xl bg-secondary p-[clamp(16px,2vw,28px)]">
       <div className="flex h-full min-h-0 gap-5">
         <InterviewPlanScheduleColumn
-          data={data}
-          isEmpty={isEmpty}
+          selectedScheduleUuid={selectedScheduleUuid}
           onToggleMenu={toggleActionsMenu}
           onOpenAddSchedule={openCreateSchedulePopup}
+          onSelectSchedule={setSelectedScheduleUuid}
         />
         <InterviewPlanCurriculumColumn
-          isEmpty={isEmpty}
-          selectedPlan={selectedPlan}
+          selectedScheduleDetail={selectedScheduleDetail}
         />
       </div>
 

--- a/src/components/home/interviewPlan/InterviewPlanSection.tsx
+++ b/src/components/home/interviewPlan/InterviewPlanSection.tsx
@@ -38,8 +38,11 @@ export default function InterviewPlanSection() {
   const deleteInterviewScheduleMutation = useMutation({
     mutationFn: deleteInterviewSchedule,
 
-    onSuccess: () => {
+    onSuccess: (_, deletedUuid) => {
       queryClient.invalidateQueries({ queryKey: ['schedules'] })
+      if (selectedScheduleUuid === deletedUuid) {
+        setSelectedScheduleUuid(null)
+      }
       setActionsMenu(null)
     },
 

--- a/src/components/home/interviewPlan/InterviewPlanSection.tsx
+++ b/src/components/home/interviewPlan/InterviewPlanSection.tsx
@@ -14,13 +14,7 @@ import InterviewScheduleRegisterPopup, {
 } from '@/components/home/interviewPlan/InterviewScheduleRegisterPopup'
 import type { InterviewPlanItem } from '@/types/interviewPlan'
 
-type InterviewPlanSectionProps = {
-  data: readonly InterviewPlanItem[]
-}
-
-export default function InterviewPlanSection({
-  data,
-}: InterviewPlanSectionProps) {
+export default function InterviewPlanSection() {
   const [selectedScheduleUuid, setSelectedScheduleUuid] = useState<
     string | null
   >(null)

--- a/src/components/home/interviewPlan/InterviewPlanSection.tsx
+++ b/src/components/home/interviewPlan/InterviewPlanSection.tsx
@@ -33,10 +33,6 @@ export default function InterviewPlanSection({
     null,
   )
 
-  const isEmpty = data.length === 0
-
-  const selectedPlan = data.find((plan) => plan.isSelected) ?? data[0] ?? null
-
   const queryClient = useQueryClient()
 
   const { data: selectedScheduleDetail } = useQuery({

--- a/src/components/home/interviewPlan/InterviewScheduleRegisterPopup.tsx
+++ b/src/components/home/interviewPlan/InterviewScheduleRegisterPopup.tsx
@@ -88,8 +88,9 @@ export default function InterviewScheduleRegisterPopup({
       uuid: string
       body: UpdateScheduleRequest
     }) => updateInterviewSchedule(uuid, body),
-    onSuccess: (data) => {
+    onSuccess: (_, variables) => {
       queryClient.invalidateQueries({ queryKey: ['schedules'] })
+      queryClient.invalidateQueries({ queryKey: ['schedule', variables.uuid] })
       onClose()
     },
     onError: (e) => {

--- a/src/components/home/interviewPlan/InterviewScheduleRegisterPopup.tsx
+++ b/src/components/home/interviewPlan/InterviewScheduleRegisterPopup.tsx
@@ -2,23 +2,27 @@
 
 import { useState } from 'react'
 import { IconCalendar } from '@tabler/icons-react'
-import { useQueryClient } from '@tanstack/react-query'
-import { useQuery, useMutation } from '@tanstack/react-query'
-import { formatFullDate } from '@/utils/date'
-import InputBox from '@/components/common/input/InputBox'
-import CalendarDropdown from '@/components/common/date/CalendarDropdown'
-import FormPopupLayout from '@/components/common/popup/FormPopupLayout'
-import { useDatePicker } from '@/hooks/useDatePicker'
-import { useModal } from '@/hooks/useModal'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+
 import {
-  getInterviewSchedule,
   createInterviewSchedule,
+  getInterviewSchedule,
   updateInterviewSchedule,
 } from '@/apis/schedules'
-import {
+import type {
   CreateScheduleRequest,
   UpdateScheduleRequest,
 } from '@/apis/schedules/type'
+import { getHttpStatus } from '@/apis/common/httpError'
+
+import CalendarDropdown from '@/components/common/date/CalendarDropdown'
+import InputBox from '@/components/common/input/InputBox'
+import HelperText from '@/components/common/text/HelperText'
+import FormPopupLayout from '@/components/common/popup/FormPopupLayout'
+
+import { useDatePicker } from '@/hooks/useDatePicker'
+import { useModal } from '@/hooks/useModal'
+import { formatFullDate } from '@/utils/date'
 
 export type InterviewSchedulePopupMode = 'create' | 'edit'
 
@@ -35,6 +39,7 @@ export default function InterviewScheduleRegisterPopup({
 }: InterviewScheduleRegisterPopupProps) {
   const { ref: popupRef } = useModal(true)
   const [companyName, setCompanyName] = useState('')
+  const [hasInterviewDateError, setHasInterviewDateError] = useState(false)
   const {
     calendarRef,
     selectedDate,
@@ -68,8 +73,10 @@ export default function InterviewScheduleRegisterPopup({
       queryClient.invalidateQueries({ queryKey: ['schedules'] })
       onClose()
     },
-    onError: (error) => {
-      console.error('생성 실패', error) //TODO: 콘솔
+    onError: (e) => {
+      if (getHttpStatus(e) === 400) {
+        setHasInterviewDateError(true)
+      }
     },
   })
 
@@ -85,8 +92,10 @@ export default function InterviewScheduleRegisterPopup({
       queryClient.invalidateQueries({ queryKey: ['schedules'] })
       onClose()
     },
-    onError: (error) => {
-      console.error('수정 실패', error) //TODO: 콘솔
+    onError: (e) => {
+      if (getHttpStatus(e) === 400) {
+        setHasInterviewDateError(true)
+      }
     },
   })
 
@@ -147,7 +156,7 @@ export default function InterviewScheduleRegisterPopup({
         <div className="relative">
           <InputBox
             id="interview-date"
-            className="border-gray-5"
+            className="border-gray-5 mb-2"
             value={dateInput}
             onChange={(e) => handleDateInputChange(e.target.value)}
             status="default"
@@ -164,6 +173,13 @@ export default function InterviewScheduleRegisterPopup({
               </button>
             }
           />
+          {hasInterviewDateError ? (
+            <HelperText status="error">
+              면접 일정은 면접일 하루 전까지만 등록할 수 있어요.
+            </HelperText>
+          ) : (
+            '\u00A0'
+          )}
           {showCalendar && (
             <CalendarDropdown
               calendarRef={calendarRef}

--- a/src/components/home/interviewPlan/InterviewScheduleRegisterPopup.tsx
+++ b/src/components/home/interviewPlan/InterviewScheduleRegisterPopup.tsx
@@ -10,6 +10,7 @@ import FormPopupLayout from '@/components/common/popup/FormPopupLayout'
 import { useDatePicker } from '@/hooks/useDatePicker'
 import { useModal } from '@/hooks/useModal'
 import {
+  getInterviewSchedule,
   createInterviewSchedule,
   updateInterviewSchedule,
 } from '@/apis/schedules'
@@ -53,6 +54,12 @@ export default function InterviewScheduleRegisterPopup({
   const canSubmit = companyName.trim().length > 0 && selectedDate !== null
 
   const queryClient = useQueryClient()
+
+  const { data: scheduleDetail } = useQuery({
+    queryKey: ['schedule', scheduleUuid],
+    queryFn: () => getInterviewSchedule(scheduleUuid!),
+    enabled: mode === 'edit' && !!scheduleUuid,
+  })
 
   const createInterviewCurriculumsMutation = useMutation({
     mutationFn: createInterviewSchedule,
@@ -126,7 +133,9 @@ export default function InterviewScheduleRegisterPopup({
           onChange={(e) => setCompanyName(e.target.value)}
           status="default"
           focusPrimary
-          placeholder="지원 회사명과 직무를 입력해주세요"
+          placeholder={
+            scheduleDetail?.companyName ?? '지원 회사명과 직무를 입력해주세요'
+          }
         />
       </div>
 
@@ -142,7 +151,7 @@ export default function InterviewScheduleRegisterPopup({
             onChange={(e) => handleDateInputChange(e.target.value)}
             status="default"
             focusPrimary
-            placeholder="0000년 00월 00일"
+            placeholder={scheduleDetail?.interviewDate ?? '0000년 00월 00일'}
             rightElement={
               <button
                 type="button"

--- a/src/components/home/interviewPlan/InterviewScheduleRegisterPopup.tsx
+++ b/src/components/home/interviewPlan/InterviewScheduleRegisterPopup.tsx
@@ -2,25 +2,34 @@
 
 import { useState } from 'react'
 import { IconCalendar } from '@tabler/icons-react'
+import { useQueryClient } from '@tanstack/react-query'
+import { useQuery, useMutation } from '@tanstack/react-query'
 import InputBox from '@/components/common/input/InputBox'
 import CalendarDropdown from '@/components/common/date/CalendarDropdown'
 import FormPopupLayout from '@/components/common/popup/FormPopupLayout'
 import { useDatePicker } from '@/hooks/useDatePicker'
 import { useModal } from '@/hooks/useModal'
+import { scheduleApi } from '@/apis/schedules'
+import {
+  CreateScheduleRequest,
+  UpdateScheduleRequest,
+} from '@/apis/schedules/type'
 
 export type InterviewSchedulePopupMode = 'create' | 'edit'
 
 interface InterviewScheduleRegisterPopupProps {
   onClose: () => void
   mode?: InterviewSchedulePopupMode
+  scheduleUuid?: string
 }
 
 export default function InterviewScheduleRegisterPopup({
   onClose,
   mode = 'create',
+  scheduleUuid,
 }: InterviewScheduleRegisterPopupProps) {
   const { ref: popupRef } = useModal(true)
-  const [companyAndRole, setCompanyAndRole] = useState('')
+  const [companyName, setCompanyName] = useState('')
   const {
     calendarRef,
     selectedDate,
@@ -38,18 +47,62 @@ export default function InterviewScheduleRegisterPopup({
     handleCancel,
   } = useDatePicker()
 
-  const canSubmit =
-    companyAndRole.trim().length > 0 && selectedDate !== null
+  const canSubmit = companyName.trim().length > 0 && selectedDate !== null
+
+  const queryClient = useQueryClient()
+
+  const createInterviewScheduleMutation = useMutation({
+    mutationFn: scheduleApi.createInterviewSchedule,
+    onSuccess: (curriculum) => {
+      console.log('생성 성공', curriculum)
+      queryClient.invalidateQueries({ queryKey: ['schedules'] })
+      onClose()
+    },
+    onError: (error) => {
+      console.error('생성 실패', error)
+    },
+  })
+
+  const updateInterviewScheduleMutation = useMutation({
+    mutationFn: ({
+      uuid,
+      body,
+    }: {
+      uuid: string
+      body: UpdateScheduleRequest
+    }) => scheduleApi.updateInterviewSchedule(uuid, body),
+    onSuccess: (data) => {
+      console.log('수정 성공', data)
+      queryClient.invalidateQueries({ queryKey: ['schedules'] })
+      onClose()
+    },
+    onError: (error) => {
+      console.error('수정 실패', error)
+    },
+  })
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault()
-    if (!canSubmit) return
-    // TODO: 면접 일정 등록·수정 API 연동
-    onClose()
+
+    if (!selectedDate) return
+
+    const request: CreateScheduleRequest = {
+      companyName: companyName,
+      interviewDate: selectedDate.toISOString().slice(0, 10),
+    }
+
+    if (mode === 'edit' && scheduleUuid) {
+      updateInterviewScheduleMutation.mutate({
+        uuid: scheduleUuid,
+        body: request,
+      })
+      return
+    }
+
+    createInterviewScheduleMutation.mutate(request)
   }
 
-  const title =
-    mode === 'edit' ? '면접 일정 수정' : '새로운 면접 일정 등록'
+  const title = mode === 'edit' ? '면접 일정 수정' : '새로운 면접 일정 등록'
   const submitLabel = mode === 'edit' ? '수정하기' : '일정등록'
 
   return (
@@ -68,8 +121,8 @@ export default function InterviewScheduleRegisterPopup({
         <InputBox
           id="interview-company-role"
           className="border-gray-5"
-          value={companyAndRole}
-          onChange={(e) => setCompanyAndRole(e.target.value)}
+          value={companyName}
+          onChange={(e) => setCompanyName(e.target.value)}
           status="default"
           focusPrimary
           placeholder="지원 회사명과 직무를 입력해주세요"

--- a/src/components/home/interviewPlan/InterviewScheduleRegisterPopup.tsx
+++ b/src/components/home/interviewPlan/InterviewScheduleRegisterPopup.tsx
@@ -9,7 +9,10 @@ import CalendarDropdown from '@/components/common/date/CalendarDropdown'
 import FormPopupLayout from '@/components/common/popup/FormPopupLayout'
 import { useDatePicker } from '@/hooks/useDatePicker'
 import { useModal } from '@/hooks/useModal'
-import { scheduleApi } from '@/apis/schedules'
+import {
+  createInterviewSchedule,
+  updateInterviewSchedule,
+} from '@/apis/schedules'
 import {
   CreateScheduleRequest,
   UpdateScheduleRequest,
@@ -52,7 +55,7 @@ export default function InterviewScheduleRegisterPopup({
   const queryClient = useQueryClient()
 
   const createInterviewCurriculumsMutation = useMutation({
-    mutationFn: scheduleApi.createInterviewSchedule,
+    mutationFn: createInterviewSchedule,
     onSuccess: (curriculum) => {
       queryClient.invalidateQueries({ queryKey: ['schedules'] })
       onClose()
@@ -69,7 +72,7 @@ export default function InterviewScheduleRegisterPopup({
     }: {
       uuid: string
       body: UpdateScheduleRequest
-    }) => scheduleApi.updateInterviewSchedule(uuid, body),
+    }) => updateInterviewSchedule(uuid, body),
     onSuccess: (data) => {
       queryClient.invalidateQueries({ queryKey: ['schedules'] })
       onClose()

--- a/src/components/home/interviewPlan/InterviewScheduleRegisterPopup.tsx
+++ b/src/components/home/interviewPlan/InterviewScheduleRegisterPopup.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react'
 import { IconCalendar } from '@tabler/icons-react'
 import { useQueryClient } from '@tanstack/react-query'
 import { useQuery, useMutation } from '@tanstack/react-query'
+import { formatFullDate } from '@/utils/date'
 import InputBox from '@/components/common/input/InputBox'
 import CalendarDropdown from '@/components/common/date/CalendarDropdown'
 import FormPopupLayout from '@/components/common/popup/FormPopupLayout'
@@ -96,7 +97,7 @@ export default function InterviewScheduleRegisterPopup({
 
     const request: CreateScheduleRequest = {
       companyName: companyName,
-      interviewDate: selectedDate.toISOString().slice(0, 10),
+      interviewDate: formatFullDate(selectedDate),
     }
 
     if (mode === 'edit' && scheduleUuid) {

--- a/src/components/home/interviewPlan/InterviewScheduleRegisterPopup.tsx
+++ b/src/components/home/interviewPlan/InterviewScheduleRegisterPopup.tsx
@@ -51,19 +51,18 @@ export default function InterviewScheduleRegisterPopup({
 
   const queryClient = useQueryClient()
 
-  const createInterviewScheduleMutation = useMutation({
+  const createInterviewCurriculumsMutation = useMutation({
     mutationFn: scheduleApi.createInterviewSchedule,
     onSuccess: (curriculum) => {
-      console.log('생성 성공', curriculum)
       queryClient.invalidateQueries({ queryKey: ['schedules'] })
       onClose()
     },
     onError: (error) => {
-      console.error('생성 실패', error)
+      console.error('생성 실패', error) //TODO: 콘솔
     },
   })
 
-  const updateInterviewScheduleMutation = useMutation({
+  const updateInterviewCurriculumsMutation = useMutation({
     mutationFn: ({
       uuid,
       body,
@@ -72,12 +71,11 @@ export default function InterviewScheduleRegisterPopup({
       body: UpdateScheduleRequest
     }) => scheduleApi.updateInterviewSchedule(uuid, body),
     onSuccess: (data) => {
-      console.log('수정 성공', data)
       queryClient.invalidateQueries({ queryKey: ['schedules'] })
       onClose()
     },
     onError: (error) => {
-      console.error('수정 실패', error)
+      console.error('수정 실패', error) //TODO: 콘솔
     },
   })
 
@@ -92,14 +90,14 @@ export default function InterviewScheduleRegisterPopup({
     }
 
     if (mode === 'edit' && scheduleUuid) {
-      updateInterviewScheduleMutation.mutate({
+      updateInterviewCurriculumsMutation.mutate({
         uuid: scheduleUuid,
         body: request,
       })
       return
     }
 
-    createInterviewScheduleMutation.mutate(request)
+    createInterviewCurriculumsMutation.mutate(request)
   }
 
   const title = mode === 'edit' ? '면접 일정 수정' : '새로운 면접 일정 등록'

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,14 +1,77 @@
+/**
+ * Date 객체를 YYYY-MM-DD 형식 문자열로 변환합니다.
+ */
 export function formatFullDate(date: Date): string {
   const year = date.getFullYear()
   const month = String(date.getMonth() + 1).padStart(2, '0')
   const day = String(date.getDate()).padStart(2, '0')
+
   return `${year}-${month}-${day}`
 }
 
-export function formatDateToLocale(isoString: string): string {
-  const date = new Date(isoString)
-  const year = date.getFullYear()
-  const month = date.getMonth() + 1
-  const day = date.getDate()
-  return `${year}년 ${month}월 ${day}일`
+/**
+ * Date 객체를 YYYY년 MM월 DD일 형식 문자열로 변환합니다.
+ */
+export function formatDateKo(date: Date): string {
+  const y = date.getFullYear()
+  const m = String(date.getMonth() + 1).padStart(2, '0')
+  const d = String(date.getDate()).padStart(2, '0')
+
+  return `${y}년 ${m}월 ${d}일`
+}
+
+/**
+ * YYYY-MM-DD 형식 문자열을 한국 날짜 포맷으로 변환합니다.
+ */
+export function formatDateToLocale(dateString: string): string {
+  return formatDateKo(parseKoreanDate(dateString))
+}
+
+/**
+ * YYYY-MM-DD 문자열을 한국 시간(KST) 기준 Date 객체로 변환합니다.
+ */
+export function parseKoreanDate(dateString: string): Date {
+  const [year, month, day] = dateString.split('-').map(Number)
+
+  return new Date(year, month - 1, day)
+}
+
+/**
+ * YYYY-MM-DD 문자열을 MM.DD 형식으로 변환합니다.
+ */
+export function formatMonthDay(dateString: string): string {
+  const date = parseKoreanDate(dateString)
+
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+
+  return `${month}.${day}`
+}
+
+/**
+ * YYYY-MM-DD 문자열 기준 D-Day 문자열을 반환합니다.
+ */
+export function getDDay(dateString: string): string {
+  const today = new Date()
+  const target = parseKoreanDate(dateString)
+
+  const todayDate = new Date(
+    today.getFullYear(),
+    today.getMonth(),
+    today.getDate(),
+  )
+
+  const targetDate = new Date(
+    target.getFullYear(),
+    target.getMonth(),
+    target.getDate(),
+  )
+
+  const diffDay = Math.ceil(
+    (targetDate.getTime() - todayDate.getTime()) / (1000 * 60 * 60 * 24),
+  )
+
+  if (diffDay === 0) return 'D-Day'
+
+  return `D-${diffDay}`
 }

--- a/src/utils/formatDate.ts
+++ b/src/utils/formatDate.ts
@@ -1,6 +1,0 @@
-export function formatDateKo(date: Date = new Date()): string {
-  const y = date.getFullYear()
-  const m = String(date.getMonth() + 1).padStart(2, '0')
-  const d = String(date.getDate()).padStart(2, '0')
-  return `${y}년 ${m}월 ${d}일`
-}


### PR DESCRIPTION
## ✨ 작업 내용

> 작업한 내용에 대한 설명을 적어주세요

- 홈 `InterviewPlan` 섹션을 목데이터 기반에서 API 기반으로 전환했습니다.
- 면접 일정 CRUD 및 상세 조회를 연동하고, 액션 메뉴/수정 모달/커리큘럼 표시 플로우를 연결했습니다.
- 날짜 포맷 및 D-day 계산 유틸을 정리하고, 기존 불필요 포맷 유틸 파일을 제거했습니다.

## 🧩 백그라운드

> 작업이 필요했던 문제 상황을 적어주세요

## 📸 스크린샷(선택)

> 스크린샷이 필요한 작업이면 스크린샷을 첨부해주세요

## ❗️관련 이슈
Closes #71 

## ✅ 테스트

- [x] 홈 진입 시 면접 일정 목록 API 데이터 표시
- [x] 일정 항목 클릭 시 해당 커리큘럼 상세 데이터 표시
- [x] 일정 생성 성공 시 목록 갱신
- [x] 일정 수정 성공 시 목록 / 상세 갱신
- [x] 일정 삭제 성공 시 목록에서 제거
- [x] `isPast` 값에 따라 커리큘럼 스타일 분기
- [x] 등록 불가 케이스(400)에서 HelperText 노출

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

> 참고할 사항이 있다면 적어주세요
