### PR TITLE
[11-311] 면접연습 종료 페이지에서 리포트 상세보기 페이지로 이동 수정

### DIFF
--- a/src/components/interview/AnalysisSection.tsx
+++ b/src/components/interview/AnalysisSection.tsx
@@ -5,6 +5,7 @@ import Image from 'next/image'
 import { useRouter, useParams } from 'next/navigation'
 import robotImg from '@/assets/image/uug-character4-img.png'
 import analysisImg from '@/assets/image/analysis-img.png'
+import Link from 'next/link'
 import Button from '@/components/common/button/Button'
 import { createInterviewSessionEventSource } from '@/apis/interview-sessions'
 import {
@@ -172,12 +173,9 @@ export default function AnalysisSection() {
             <p className="h1 text-primary">면접 분석이 완료되었어요!</p>
             <p className="p1 text-gray-1">
               생성된 리포트는{' '}
-              <span
-                className="text-primary cursor-pointer"
-                onClick={() => router.push('/history')}
-              >
+              <Link href="/history" className="text-primary">
                 연습 이력
-              </span>{' '}
+              </Link>{' '}
               에서 저장되었습니다.
             </p>
           </div>
@@ -214,12 +212,9 @@ export default function AnalysisSection() {
             </p>
             <p className="p1 text-gray-1">
               페이지를 벗어나도 분석은 중단되지 않으며,{' '}
-              <span
-                className="text-primary cursor-pointer"
-                onClick={() => router.push('/history')}
-              >
+              <Link href="/history" className="text-primary">
                 연습 이력
-              </span>{' '}
+              </Link>{' '}
               에서 확인하실 수 있습니다.
             </p>
           </div>

--- a/src/components/interview/AnalysisSection.tsx
+++ b/src/components/interview/AnalysisSection.tsx
@@ -118,7 +118,7 @@ export default function AnalysisSection() {
       onerror(err) {
         throw err
       },
-    }).catch((err) => {
+    }).catch(() => {
       clearInterval(progressTimer)
       if (streamFinished || controller.signal.aborted) return
       startPolling()
@@ -172,7 +172,12 @@ export default function AnalysisSection() {
             <p className="h1 text-primary">면접 분석이 완료되었어요!</p>
             <p className="p1 text-gray-1">
               생성된 리포트는{' '}
-              <span className="text-primary cursor-pointer">연습 이력</span>{' '}
+              <span
+                className="text-primary cursor-pointer"
+                onClick={() => router.push('/history')}
+              >
+                연습 이력
+              </span>{' '}
               에서 저장되었습니다.
             </p>
           </div>
@@ -187,7 +192,7 @@ export default function AnalysisSection() {
 
           <Button
             className="rounded-full! py-3! px-18.25! mt-3.5"
-            onClick={() => router.push('/history')}
+            onClick={() => router.push(`/history/${uuid}`)}
           >
             <span className="h3">리포트 보러가기</span>
           </Button>
@@ -209,7 +214,12 @@ export default function AnalysisSection() {
             </p>
             <p className="p1 text-gray-1">
               페이지를 벗어나도 분석은 중단되지 않으며,{' '}
-              <span className="text-primary cursor-pointer">연습 이력</span>{' '}
+              <span
+                className="text-primary cursor-pointer"
+                onClick={() => router.push('/history')}
+              >
+                연습 이력
+              </span>{' '}
               에서 확인하실 수 있습니다.
             </p>
           </div>


### PR DESCRIPTION
## ✨ 작업 내용

> 작업한 내용에 대한 설명을 적어주세요
- 분석중, 분석 완료에서 연습이력으로 이동 가능하도록 수정
- 분석 완료에서 리포트 바로 이동 가능

## 🧩 백그라운드

> 작업이 필요했던 문제 상황을 적어주세요

## 📸 스크린샷(선택)

> 스크린샷이 필요한 작업이면 스크린샷을 첨부해주세요

## ✅ 테스트

- [x] 정상 동작 확인

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

> 참고할 사항이 있다면 적어주세요
