### PR TITLE
[fix] 헤더 로그아웃 시 리다이렉팅 수정 몆 채용 공고 분석 UX 개선

### DIFF
--- a/src/components/common/header/Header.tsx
+++ b/src/components/common/header/Header.tsx
@@ -2,6 +2,7 @@
 
 import Image from 'next/image'
 import Link from 'next/link'
+import { useRouter } from 'next/navigation'
 import { useState, useRef, useEffect } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import {
@@ -29,6 +30,7 @@ const NAV_LINKS = [
 ]
 
 export default function Header({ className = '' }: HeaderProps) {
+  const router = useRouter()
   const [open, setOpen] = useState(false)
   const [queryEnabled, setQueryEnabled] = useState<boolean | null>(null)
   const dropdownRef = useRef<HTMLDivElement>(null)
@@ -65,6 +67,7 @@ export default function Header({ className = '' }: HeaderProps) {
       queryClient.removeQueries({ queryKey: ['user', 'profile'] })
       setQueryEnabled(false)
       setOpen(false)
+      router.replace('/')
     },
   })
 

--- a/src/components/interview/JobPostingFormSection.tsx
+++ b/src/components/interview/JobPostingFormSection.tsx
@@ -169,7 +169,7 @@ export default function JobPostingFormSection() {
           onClose={handleClose}
         />
       )}
-      {popupState === 'generateQuestioncomplete' && (
+      {popupState === 'generateQuestionComplete' && (
         <CompletePopup
           popupRef={popupRef}
           title="질문 생성이 완료되었어요!"

--- a/src/components/interview/JobPostingFormSection.tsx
+++ b/src/components/interview/JobPostingFormSection.tsx
@@ -74,6 +74,7 @@ export default function JobPostingFormSection() {
     handleClose,
     handleCompanyNameSubmit,
     handleStartInterview,
+    handleStartQuestionGeneration,
   } = useJobPostingAnalysisFlow()
 
   const { ref: popupRef } = useModal(popupState !== null)
@@ -149,6 +150,15 @@ export default function JobPostingFormSection() {
           onSubmit={handleCompanyNameSubmit}
         />
       )}
+      {popupState === 'analysisComplete' && (
+        <CompletePopup
+          popupRef={popupRef}
+          title="채용 공고 분석이 완료되었어요!"
+          subtitle={`${companyName} 질문 생성을 시작해주세요.`}
+          actionLabel="시작하기"
+          onAction={handleStartQuestionGeneration}
+        />
+      )}
       {popupState === 'generating' && (
         <GeneratingPopup popupRef={popupRef} onClose={handleClose} />
       )}
@@ -157,15 +167,6 @@ export default function JobPostingFormSection() {
           popupRef={popupRef}
           title="질문 생성에 실패했어요"
           onClose={handleClose}
-        />
-      )}
-      {popupState === 'analysisComplete' && (
-        <CompletePopup
-          popupRef={popupRef}
-          title="채용 공고 분석이 완료되었어요!"
-          subtitle={`${companyName} 질문 생성을 시작해주세요.`}
-          actionLabel="시작하기"
-          onAction={handleStartInterview}
         />
       )}
       {popupState === 'generateQuestioncomplete' && (

--- a/src/components/interview/JobPostingFormSection.tsx
+++ b/src/components/interview/JobPostingFormSection.tsx
@@ -25,12 +25,16 @@ function isValidUrl(value: string): boolean {
 
 function CompletePopup({
   popupRef,
-  companyName,
-  onStart,
+  title,
+  subtitle,
+  actionLabel,
+  onAction,
 }: {
   popupRef: React.RefObject<HTMLDivElement | null>
-  companyName: string
-  onStart: () => void
+  title: string
+  subtitle: string
+  actionLabel: string
+  onAction: () => void
 }) {
   return (
     <div className="fixed inset-0 bg-black/13 flex items-center justify-center z-50">
@@ -40,20 +44,20 @@ function CompletePopup({
       >
         <Image
           src={character3}
-          alt="캐릭터"
+          alt=""
           width={163}
           height={163}
           className="object-contain mb-5.5"
         />
-        <div className="flex flex-col items-center gap-1.75">
-          <p className="h1 text-primary">질문 생성이 완료되었어요!</p>
-          <p className="p1 text-gray-2">{companyName} 면접을 시작해주세요.</p>
+        <div className="flex flex-col items-center gap-1.75 text-center px-6">
+          <p className="h1 text-primary">{title}</p>
+          <p className="p1 text-gray-2">{subtitle}</p>
         </div>
         <Button
           className="w-70 rounded-full! py-3 cursor-pointer mt-12"
-          onClick={onStart}
+          onClick={onAction}
         >
-          <span className="h3">시작 하기</span>
+          <span className="h3">{actionLabel}</span>
         </Button>
       </div>
     </div>
@@ -155,11 +159,22 @@ export default function JobPostingFormSection() {
           onClose={handleClose}
         />
       )}
-      {popupState === 'complete' && (
+      {popupState === 'analysisComplete' && (
         <CompletePopup
           popupRef={popupRef}
-          companyName={companyName}
-          onStart={handleStartInterview}
+          title="채용 공고 분석이 완료되었어요!"
+          subtitle={`${companyName} 질문 생성을 시작해주세요.`}
+          actionLabel="시작하기"
+          onAction={handleStartInterview}
+        />
+      )}
+      {popupState === 'generateQuestioncomplete' && (
+        <CompletePopup
+          popupRef={popupRef}
+          title="질문 생성이 완료되었어요!"
+          subtitle={`${companyName} 면접을 시작해주세요.`}
+          actionLabel="시작하기"
+          onAction={handleStartInterview}
         />
       )}
       {popupState === 'sessionCreating' && (

--- a/src/components/interview/jobPostingAnalysis/useJobPostingAnalysisFlow.ts
+++ b/src/components/interview/jobPostingAnalysis/useJobPostingAnalysisFlow.ts
@@ -23,7 +23,7 @@ export type JobPostingAnalysisPopupState =
   | 'generating'
   | 'questionFailed'
   | 'analysisComplete'
-  | 'generateQuestioncomplete'
+  | 'generateQuestionComplete'
   | 'sessionCreating'
   | 'sessionFailed'
   | null
@@ -137,7 +137,7 @@ export function useJobPostingAnalysisFlow() {
       setPopupState('generating')
 
       generatingTimerRef.current = setTimeout(() => {
-        setPopupState('generateQuestioncomplete')
+        setPopupState('generateQuestionComplete')
       }, GENERATING_DELAY_MS)
     },
 

--- a/src/components/interview/jobPostingAnalysis/useJobPostingAnalysisFlow.ts
+++ b/src/components/interview/jobPostingAnalysis/useJobPostingAnalysisFlow.ts
@@ -132,9 +132,18 @@ export function useJobPostingAnalysisFlow() {
   // Interview session SSE (공통 훅으로 위임)
   useWaitForSessionQuestions({
     sessionUuid,
-    onReady: (uuid) =>
-      router.push(`/interview/job-posting/${uuid}/countdown?q=1`),
-    onError: () => setPopupState('sessionFailed'),
+
+    onReady: () => {
+      setPopupState('generating')
+
+      generatingTimerRef.current = setTimeout(() => {
+        setPopupState('generateQuestioncomplete')
+      }, GENERATING_DELAY_MS)
+    },
+
+    onError: () => {
+      setPopupState('sessionFailed')
+    },
   })
 
   useEffect(() => {
@@ -233,7 +242,7 @@ export function useJobPostingAnalysisFlow() {
     )
   }
 
-  function handleStartInterview() {
+  function handleStartQuestionGeneration() {
     if (!jobPostingUuid) return
     setPopupState('sessionCreating')
     createSessionMutation.mutate({
@@ -241,6 +250,12 @@ export function useJobPostingAnalysisFlow() {
       interviewDate: new Date().toISOString().split('T')[0],
       retry: false,
     })
+  }
+
+  function handleStartInterview() {
+    if (!sessionUuid) return
+
+    router.push(`/interview/job-posting/${sessionUuid}/countdown?q=1`)
   }
 
   return {
@@ -251,5 +266,6 @@ export function useJobPostingAnalysisFlow() {
     handleClose,
     handleCompanyNameSubmit,
     handleStartInterview,
+    handleStartQuestionGeneration,
   }
 }

--- a/src/components/interview/jobPostingAnalysis/useJobPostingAnalysisFlow.ts
+++ b/src/components/interview/jobPostingAnalysis/useJobPostingAnalysisFlow.ts
@@ -22,7 +22,8 @@ export type JobPostingAnalysisPopupState =
   | 'companyName'
   | 'generating'
   | 'questionFailed'
-  | 'complete'
+  | 'analysisComplete'
+  | 'generateQuestioncomplete'
   | 'sessionCreating'
   | 'sessionFailed'
   | null
@@ -45,9 +46,8 @@ export function useJobPostingAnalysisFlow() {
       if (name) {
         setCompanyName(name)
         setPosition(detail.position || '')
-        setPopupState('generating')
         generatingTimerRef.current = setTimeout(
-          () => setPopupState('complete'),
+          () => setPopupState('analysisComplete'),
           GENERATING_DELAY_MS,
         )
       } else {
@@ -222,7 +222,7 @@ export function useJobPostingAnalysisFlow() {
           setCompanyName(trimmed)
           setPopupState('generating')
           generatingTimerRef.current = setTimeout(
-            () => setPopupState('complete'),
+            () => setPopupState('analysisComplete'),
             GENERATING_DELAY_MS,
           )
         },


### PR DESCRIPTION
## ✨ 작업 내용

> 작업한 내용에 대한 설명을 적어주세요

- 헤더 리다이렉팅을 `/login`으로 수정하였습니다.
- 채용 공고 분석 완료 팝업을 추가하고 질문 생성 및 면접 세션 생성이 완료되면 바로 문제 페이지로 넘어가는 UX를 개선하였습니다.


## 🧩 백그라운드

> 작업이 필요했던 문제 상황을 적어주세요

- 헤더에서 리다이렉팅 시 현재 페이지에 잔류하는 문제가 발생하였습니다.
- 질문 생성 팝업이 이중으로 랜더링되는 문제가 발생하였습니다.

## 📸 스크린샷(선택)

> 스크린샷이 필요한 작업이면 스크린샷을 첨부해주세요

<img width="929" height="753" alt="스크린샷 2026-05-10 오전 2 37 03" src="https://github.com/user-attachments/assets/77e4a12b-4b76-4e67-8c17-f373332206f9" />

## ✅ 테스트

- [x] 정상 동작 확인

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

> 참고할 사항이 있다면 적어주세요
