### PR TITLE
[fix] 회원가입 관련 버그 수정

### DIFF
--- a/src/apis/user/index.ts
+++ b/src/apis/user/index.ts
@@ -27,6 +27,10 @@ export const checkNicknameAvailability = async (nickname: string) => {
   await publicClient.get('/users/nickname-check', { params: { nickname } })
 }
 
+export const checkEmailAvailability = async (email: string) => {
+  await publicClient.get('/users/email-check', { params: { email } })
+}
+
 export const sendEmailVerificationCode = async (body: EmailField) => {
   const { data } = await privateClient.post<ApiResponse<string>>(
     '/users/email-verifications',

--- a/src/components/auth/signup/EmailSection.tsx
+++ b/src/components/auth/signup/EmailSection.tsx
@@ -2,8 +2,10 @@
 
 import { useEffect, useRef, useState } from 'react'
 import { useMutation } from '@tanstack/react-query'
+import { isAxiosError } from 'axios'
 import { EMAIL_REGEX } from '@/constants/regex'
 import { signupApi } from '@/apis/auth'
+import { checkEmailAvailability } from '@/apis/user'
 import Button from '@/components/common/button/Button'
 import InputBox from '@/components/common/input/InputBox'
 import HelperText from '@/components/common/text/HelperText'
@@ -28,15 +30,9 @@ function formatTime(seconds: number) {
 
 interface EmailSectionProps {
   onEmailVerified?: (verified: boolean) => void
-  serverError?: string
-  onClearServerError?: () => void
 }
 
-export default function EmailSection({
-  onEmailVerified,
-  serverError,
-  onClearServerError,
-}: EmailSectionProps) {
+export default function EmailSection({ onEmailVerified }: EmailSectionProps) {
   const [email, setEmail] = useState('')
   const [code, setCode] = useState('')
   const [emailStatus, setEmailStatus] = useState<FieldStatus>('default')
@@ -93,15 +89,22 @@ export default function EmailSection({
   }
 
   const sendCodeMutation = useMutation({
-    mutationFn: signupApi.sendEmailVerificationCode,
+    mutationFn: async (email: string) => {
+      await checkEmailAvailability(email)
+      await signupApi.sendEmailVerificationCode({ email })
+    },
     onSuccess: () => {
       setEmailHelper({ text: '전송 완료', status: 'success' })
       setEmailStatus('success')
       startTimer()
       startCooldown()
     },
-    onError: () => {
-      setEmailHelper({ text: '이메일 전송에 실패했습니다.', status: 'error' })
+    onError: (err) => {
+      const message =
+        isAxiosError(err) && err.response?.data?.message
+          ? err.response.data.message
+          : '이메일 전송에 실패했습니다.'
+      setEmailHelper({ text: message, status: 'error' })
       setEmailStatus('error')
     },
   })
@@ -109,7 +112,10 @@ export default function EmailSection({
   const verifyCodeMutation = useMutation({
     mutationFn: signupApi.verifyEmailVerification,
     onSuccess: () => {
-      if (timerRef.current) clearInterval(timerRef.current)
+      if (timerRef.current) {
+        clearInterval(timerRef.current)
+        timerRef.current = null
+      }
       setTimeLeft(null)
       setCodeHelper({ text: '인증 완료', status: 'success' })
       setCodeStatus('success')
@@ -136,7 +142,7 @@ export default function EmailSection({
     setEmailHelper(EMPTY)
     setEmailStatus('default')
     onEmailVerified?.(false)
-    sendCodeMutation.mutate({ email })
+    sendCodeMutation.mutate(email)
   }
 
   function handleVerifyCode() {
@@ -165,7 +171,6 @@ export default function EmailSection({
               setEmailStatus('default')
               setEmailHelper(EMPTY)
               onEmailVerified?.(false)
-              onClearServerError?.()
             }}
             placeholder="이메일을 입력해주세요."
             status={emailStatus}
@@ -179,18 +184,10 @@ export default function EmailSection({
             {codeSent ? '재전송' : '인증번호'}
           </Button>
         </div>
-        <HelperText
-          status={
-            cooldownLeft > 0
-              ? 'default'
-              : serverError
-                ? 'error'
-                : emailHelper.status
-          }
-        >
+        <HelperText status={cooldownLeft > 0 ? 'default' : emailHelper.status}>
           {cooldownLeft > 0
             ? `${cooldownLeft}초 후에 다시 전송할 수 있습니다.`
-            : serverError || emailHelper.text}
+            : emailHelper.text}
         </HelperText>
       </div>
       <div className="flex flex-col gap-2">

--- a/src/components/auth/signup/EmailSection.tsx
+++ b/src/components/auth/signup/EmailSection.tsx
@@ -44,16 +44,40 @@ export default function EmailSection({
   const [emailHelper, setEmailHelper] = useState<HelperState>(EMPTY)
   const [codeHelper, setCodeHelper] = useState<HelperState>(EMPTY)
   const [timeLeft, setTimeLeft] = useState<number | null>(null)
+  const [cooldownLeft, setCooldownLeft] = useState(0)
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const cooldownRef = useRef<ReturnType<typeof setInterval> | null>(null)
 
   const codeSent = timeLeft !== null
   const timerExpired = timeLeft === 0
 
   useEffect(() => {
+    if (timerExpired) {
+      setCodeHelper({ text: '인증시간이 만료되었습니다.', status: 'error' })
+      setCodeStatus('error')
+    }
+  }, [timerExpired])
+
+  useEffect(() => {
     return () => {
       if (timerRef.current) clearInterval(timerRef.current)
+      if (cooldownRef.current) clearInterval(cooldownRef.current)
     }
   }, [])
+
+  function startCooldown() {
+    if (cooldownRef.current) clearInterval(cooldownRef.current)
+    setCooldownLeft(30)
+    cooldownRef.current = setInterval(() => {
+      setCooldownLeft((c) => {
+        if (c <= 1) {
+          clearInterval(cooldownRef.current!)
+          return 0
+        }
+        return c - 1
+      })
+    }, 1000)
+  }
 
   function startTimer() {
     if (timerRef.current) clearInterval(timerRef.current)
@@ -75,6 +99,7 @@ export default function EmailSection({
       setEmailHelper({ text: '전송 완료', status: 'success' })
       setEmailStatus('success')
       startTimer()
+      startCooldown()
     },
     onError: () => {
       setEmailHelper({ text: '이메일 전송에 실패했습니다.', status: 'error' })
@@ -106,6 +131,10 @@ export default function EmailSection({
       setEmailStatus('error')
       return
     }
+    setCode('')
+    setCodeStatus('default')
+    setCodeHelper(EMPTY)
+    onEmailVerified?.(false)
     sendCodeMutation.mutate({ email })
   }
 
@@ -142,15 +171,25 @@ export default function EmailSection({
           />
           <Button
             onClick={handleSendCode}
-            disabled={sendCodeMutation.isPending || (codeSent && !timerExpired)}
+            disabled={sendCodeMutation.isPending || cooldownLeft > 0}
             variant={codeSent ? 'secondary' : 'primary'}
             className={codeSent ? 'bg-primary-light text-primary' : ''}
           >
             {codeSent ? '재전송' : '인증번호'}
           </Button>
         </div>
-        <HelperText status={serverError ? 'error' : emailHelper.status}>
-          {serverError || emailHelper.text}
+        <HelperText
+          status={
+            cooldownLeft > 0
+              ? 'default'
+              : serverError
+                ? 'error'
+                : emailHelper.status
+          }
+        >
+          {cooldownLeft > 0
+            ? `${cooldownLeft}초 후에 다시 전송할 수 있습니다.`
+            : serverError || emailHelper.text}
         </HelperText>
       </div>
       <div className="flex flex-col gap-2">
@@ -172,7 +211,7 @@ export default function EmailSection({
           />
           <Button
             onClick={handleVerifyCode}
-            disabled={verifyCodeMutation.isPending}
+            disabled={verifyCodeMutation.isPending || timerExpired || !codeSent}
           >
             인증확인
           </Button>

--- a/src/components/auth/signup/EmailSection.tsx
+++ b/src/components/auth/signup/EmailSection.tsx
@@ -53,6 +53,10 @@ export default function EmailSection({
 
   useEffect(() => {
     if (timerExpired) {
+      if (timerRef.current) {
+        clearInterval(timerRef.current)
+        timerRef.current = null
+      }
       setCodeHelper({ text: '인증시간이 만료되었습니다.', status: 'error' })
       setCodeStatus('error')
     }
@@ -65,17 +69,18 @@ export default function EmailSection({
     }
   }, [])
 
+  useEffect(() => {
+    if (cooldownLeft === 0 && cooldownRef.current) {
+      clearInterval(cooldownRef.current)
+      cooldownRef.current = null
+    }
+  }, [cooldownLeft])
+
   function startCooldown() {
     if (cooldownRef.current) clearInterval(cooldownRef.current)
     setCooldownLeft(30)
     cooldownRef.current = setInterval(() => {
-      setCooldownLeft((c) => {
-        if (c <= 1) {
-          clearInterval(cooldownRef.current!)
-          return 0
-        }
-        return c - 1
-      })
+      setCooldownLeft((c) => (c <= 1 ? 0 : c - 1))
     }, 1000)
   }
 
@@ -83,13 +88,7 @@ export default function EmailSection({
     if (timerRef.current) clearInterval(timerRef.current)
     setTimeLeft(180)
     timerRef.current = setInterval(() => {
-      setTimeLeft((t) => {
-        if (t === null || t <= 1) {
-          clearInterval(timerRef.current!)
-          return 0
-        }
-        return t - 1
-      })
+      setTimeLeft((t) => (t === null || t <= 1 ? 0 : t - 1))
     }, 1000)
   }
 
@@ -134,6 +133,8 @@ export default function EmailSection({
     setCode('')
     setCodeStatus('default')
     setCodeHelper(EMPTY)
+    setEmailHelper(EMPTY)
+    setEmailStatus('default')
     onEmailVerified?.(false)
     sendCodeMutation.mutate({ email })
   }

--- a/src/components/auth/signup/SignUpForm.tsx
+++ b/src/components/auth/signup/SignUpForm.tsx
@@ -28,7 +28,6 @@ export default function SignUpForm() {
     [],
   )
   const [submitError, setSubmitError] = useState('')
-  const [emailError, setEmailError] = useState('')
 
   const handlePasswordValid = useCallback(
     (valid: boolean) => setPasswordValid(valid),
@@ -48,12 +47,7 @@ export default function SignUpForm() {
         isAxiosError(err) && err.response?.data?.message
           ? err.response.data.message
           : '회원가입에 실패했습니다. 다시 시도해주세요.'
-      if (message.includes('이메일')) {
-        setEmailError(message)
-        setEmailVerified(false)
-      } else {
-        setSubmitError(message)
-      }
+      setSubmitError(message)
     },
   })
 
@@ -65,7 +59,6 @@ export default function SignUpForm() {
 
     const formData = new FormData(e.currentTarget)
     setSubmitError('')
-    setEmailError('')
     signupMutation.mutate({
       email: formData.get('email') as string,
       password: formData.get('password') as string,
@@ -77,11 +70,7 @@ export default function SignUpForm() {
 
   return (
     <form className="flex flex-col gap-5.5" onSubmit={handleSubmit}>
-      <EmailSection
-        onEmailVerified={setEmailVerified}
-        serverError={emailError}
-        onClearServerError={() => setEmailError('')}
-      />
+      <EmailSection onEmailVerified={setEmailVerified} />
       <PasswordSection onPasswordValid={handlePasswordValid} />
       <NicknameSection onNicknameChecked={setNicknameChecked} />
       <TermsSection onChange={handleTermsChange} />


### PR DESCRIPTION
## ✨ 작업 내용

> 작업한 내용에 대한 설명을 적어주세요
- 인증번호 재전송 불가
    - 인증 타이머가 살아있어도 재전송 버튼 누를 수 있도록 변경
    - 재전송 시 인증번호 입력란 초기화
- 이메일 인증 시간 초과
    - 타이머 3분 경과 시 자동으로 "인증시간이 만료되었습니다." 메시지 표시
    - 만료 시 인증확인 버튼 비활성화
- 재전송 스팸 방지 쿨다운
    - 전송 성공 후 30초간 재전송 버튼 비활성화
    - 이메일 변경해도 쿨다운 유지 (스팸 악용 방지)
    - 헬퍼텍스트에 30초 후에 다시 전송할 수 있습니다. 카운트다운 표시
- 인증확인 버튼
    - 인증번호 전송 전엔 비활성화, 전송 후부터 활성화
- 인증 번호 발송 시 이미 가입된 이메일 중복 체크

## 🧩 백그라운드

> 작업이 필요했던 문제 상황을 적어주세요
#119 #120 #125

## 📸 스크린샷(선택)

> 스크린샷이 필요한 작업이면 스크린샷을 첨부해주세요

## ✅ 테스트

- [x] 정상 동작 확인

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

> 참고할 사항이 있다면 적어주세요
