### PR TITLE
[refactor] 스크립트 관련 수정

### DIFF
--- a/src/components/interview/QuestionSection.tsx
+++ b/src/components/interview/QuestionSection.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useRef, Fragment } from 'react'
+import { useState, useRef, useEffect, Fragment } from 'react'
 import { useRouter, useParams } from 'next/navigation'
 import Image from 'next/image'
 import { useMutation, useQuery } from '@tanstack/react-query'
@@ -65,6 +65,8 @@ export default function QuestionSection({
   const [isStopPopupOpen, setIsStopPopupOpen] = useState(false)
   const wasPausedBeforePopupRef = useRef(false)
 
+  const scriptRef = useRef<HTMLDivElement>(null)
+
   const {
     elapsedMs,
     elapsedMsRef,
@@ -77,6 +79,13 @@ export default function QuestionSection({
     pause: speechPause,
     resume: speechResume,
   } = useSpeechRecognition()
+
+  useEffect(() => {
+    if (scriptRef.current) {
+      scriptRef.current.scrollTop = scriptRef.current.scrollHeight
+    }
+  }, [transcript, interimTranscript])
+
   const {
     volumeBars,
     dbValue,
@@ -302,14 +311,19 @@ export default function QuestionSection({
           {/* 하단: 스크립트 + 볼륨/침묵 */}
           <div className="flex gap-7.75 shrink-0">
             <div className="flex flex-col flex-1">
-              <div className="bg-secondary rounded-xl p-6.75 h-42 overflow-hidden flex flex-col gap-2">
+              <div className="bg-secondary rounded-xl p-6.75 h-42 flex flex-col gap-2">
                 <span className="p2 text-gray-1 shrink-0">스크립트</span>
-                <p className="p4 text-gray-4 leading-relaxed">
-                  <HighlightedText text={transcript} />
-                  <span className="opacity-50">
-                    <HighlightedText text={interimTranscript} />
-                  </span>
-                </p>
+                <div
+                  ref={scriptRef}
+                  className="overflow-y-auto [&::-webkit-scrollbar]:hidden flex-1"
+                >
+                  <p className="p4 text-gray-4 leading-relaxed">
+                    <HighlightedText text={transcript} />
+                    <span className="opacity-50">
+                      <HighlightedText text={interimTranscript} />
+                    </span>
+                  </p>
+                </div>
               </div>
             </div>
 

--- a/src/hooks/useSpeechRecognition.ts
+++ b/src/hooks/useSpeechRecognition.ts
@@ -26,6 +26,8 @@ export function useSpeechRecognition() {
   const [interimTranscript, setInterimTranscript] = useState('')
   const recognitionRef = useRef<ISpeechRecognition | null>(null)
   const isPausedRef = useRef(false)
+  const accumulatedRef = useRef('')
+  const latestFinalRef = useRef('')
 
   useEffect(() => {
     const SR = window.SpeechRecognition ?? window.webkitSpeechRecognition
@@ -36,9 +38,6 @@ export function useSpeechRecognition() {
     recognition.continuous = true
     recognition.interimResults = true
 
-    const accumulatedRef = { current: '' }
-    const latestFinalRef = { current: '' }
-
     recognition.onresult = (e: ISpeechRecognitionEvent) => {
       let final = ''
       let interim = ''
@@ -48,7 +47,7 @@ export function useSpeechRecognition() {
       }
       latestFinalRef.current = final
       setTranscript(
-        accumulatedRef.current ? accumulatedRef.current + ' ' + final : final,
+        (accumulatedRef.current + ' ' + final).replace(/\s+/g, ' ').trim(),
       )
       setInterimTranscript(interim)
     }

--- a/src/hooks/useSpeechRecognition.ts
+++ b/src/hooks/useSpeechRecognition.ts
@@ -36,6 +36,9 @@ export function useSpeechRecognition() {
     recognition.continuous = true
     recognition.interimResults = true
 
+    const accumulatedRef = { current: '' }
+    const latestFinalRef = { current: '' }
+
     recognition.onresult = (e: ISpeechRecognitionEvent) => {
       let final = ''
       let interim = ''
@@ -43,11 +46,20 @@ export function useSpeechRecognition() {
         if (e.results[i].isFinal) final += e.results[i][0].transcript
         else interim += e.results[i][0].transcript
       }
-      setTranscript(final)
+      latestFinalRef.current = final
+      setTranscript(
+        accumulatedRef.current ? accumulatedRef.current + ' ' + final : final,
+      )
       setInterimTranscript(interim)
     }
 
     recognition.onend = () => {
+      accumulatedRef.current = (
+        accumulatedRef.current +
+        ' ' +
+        latestFinalRef.current
+      ).trim()
+      latestFinalRef.current = ''
       if (!isPausedRef.current) recognition.start()
     }
 


### PR DESCRIPTION
- 스크립트 자동 스크롤
    - 텍스트가 4줄 넘으면 최신 텍스트 기준으로 자동 스크롤
- transcript 누적 버그 수정
    - 브라우저가 무음 감지로 인식을 끊고 재시작할 때 기존 transcript가 초기화되던 문제 수정
    - accumulatedRef로 이전 세션 텍스트를 보존하고 이어붙임
- 세션 간 공백 누락 버그 수정
    - transcript 수정으로 인해 세션이 끊기고 이어붙을 때 공백 없이 붙던 문제 수정

## ✨ 작업 내용

> 작업한 내용에 대한 설명을 적어주세요

## 🧩 백그라운드

> 작업이 필요했던 문제 상황을 적어주세요

## 📸 스크린샷(선택)

> 스크린샷이 필요한 작업이면 스크린샷을 첨부해주세요

## ✅ 테스트

- [x] 정상 동작 확인

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

> 참고할 사항이 있다면 적어주세요
