### PR TITLE
[fix] 퍼블리싱 수정

### DIFF
--- a/src/components/history/HistorySection.tsx
+++ b/src/components/history/HistorySection.tsx
@@ -8,6 +8,9 @@ import {
   type InterviewReportListItem,
 } from '@/apis/interview-reports'
 import { formatMonthDayKo, formatDuration } from '@/utils/date'
+import { ellipsizeText } from '@/utils/ellipsizeText'
+
+const POSITION_DISPLAY_MAX_CHARS = 15
 
 interface CompanyGroup {
   companyName: string
@@ -188,7 +191,9 @@ function HistoryCard({
         <span className="p2 border border-primary text-primary rounded-full px-2.5 py-0.5 bg-secondary whitespace-nowrap self-center">
           {session.attemptNumber}차 시도
         </span>
-        <span className="h3">{session.position ?? '-'}</span>
+        <span className="h3">
+          {ellipsizeText(session.position, POSITION_DISPLAY_MAX_CHARS)}
+        </span>
         <span className="p4 text-gray-4 col-start-2">
           {dateLabel} · {session.questionCount}문항 · {duration}
         </span>

--- a/src/components/home/interviewPlan/InterviewPlanScheduleColumn.tsx
+++ b/src/components/home/interviewPlan/InterviewPlanScheduleColumn.tsx
@@ -80,7 +80,7 @@ export default function InterviewPlanScheduleColumn({
                 'flex h-14 items-center justify-between rounded-lg border bg-white px-5 py-3 gap-3 cursor-pointer',
                 selectedScheduleUuid === schedule.scheduleUuid
                   ? 'border-primary'
-                  : 'border-gray-5 ',
+                  : 'border-gray-5',
               ].join(' ')}
             >
               <div className="flex items-center gap-4 overflow-hidden min-w-0 flex-1">

--- a/src/components/home/interviewPlan/InterviewPlanScheduleColumn.tsx
+++ b/src/components/home/interviewPlan/InterviewPlanScheduleColumn.tsx
@@ -56,7 +56,7 @@ export default function InterviewPlanScheduleColumn({
             >
               {row.leading === 'prompt' ? (
                 <div className="flex items-center gap-3 min-w-0">
-                  <span className="h2 text-primary shrink-0">D-day</span>
+                  <span className="h4 text-primary shrink-0">D-day</span>
                   <span className="p4 text-gray-3 truncate">
                     면접 일정을 등록해주세요
                   </span>
@@ -80,7 +80,7 @@ export default function InterviewPlanScheduleColumn({
                 'flex h-14 items-center justify-between rounded-lg border bg-white px-5 py-3 gap-3 cursor-pointer',
                 selectedScheduleUuid === schedule.scheduleUuid
                   ? 'border-primary'
-                  : 'border-gray-5',
+                  : 'border-gray-5 ',
               ].join(' ')}
             >
               <div className="flex items-center gap-4 overflow-hidden min-w-0 flex-1">

--- a/src/components/home/todaySchedule/TodayScheduleSection.tsx
+++ b/src/components/home/todaySchedule/TodayScheduleSection.tsx
@@ -6,9 +6,9 @@ import { useQuery } from '@tanstack/react-query'
 import { getCurriculumsByDate } from '@/apis/curriculum'
 import { formatFullDate } from '@/utils/date'
 import { getWeekDates } from '@/utils/getWeekDates'
+import { ellipsizeText } from '@/utils/ellipsizeText'
 
-const formatCompanyName = (name: string) =>
-  name.length > 10 ? `${name.slice(0, 10)}...` : name
+const COMPANY_NAME_MAX_CHARS = 10
 
 export default function TodayScheduleSection() {
   const [isNextWeek, setIsNextWeek] = useState(false)
@@ -109,7 +109,7 @@ export default function TodayScheduleSection() {
                 >
                   <div className="flex items-center gap-3">
                     <span className="p4 text-primary">
-                      {formatCompanyName(item.companyName)}
+                      {ellipsizeText(item.companyName, COMPANY_NAME_MAX_CHARS)}
                     </span>
                     <p className="p3 text-text-primary">{item.content}</p>
                   </div>

--- a/src/components/ranking/RankingCard.tsx
+++ b/src/components/ranking/RankingCard.tsx
@@ -38,7 +38,7 @@ export default function RankingCard({
         isPrimary
           ? `border-primary text-primary ${bgWhite ? 'bg-white' : 'bg-secondary'}`
           : 'border-gray-5 bg-white text-text-primary',
-        isLarge ? 'min-h-36 px-16 py-14' : 'min-h-26 px-12 py-8',
+        isLarge ? 'min-h-36 px-16 py-11 ' : 'min-h-26 px-12 py-7',
       ].join(' ')}
     >
       <div
@@ -67,7 +67,7 @@ export default function RankingCard({
       </div>
 
       <div
-        className={`text-4xl font-bold ${isPrimary && isLarge ? 'text-primary' : 'text-gray-1'}`}
+        className={`text-4xl font-bold ${isPrimary ? 'text-primary' : 'text-gray-1'}`}
       >
         {bestScore}점
       </div>

--- a/src/components/ranking/RankingCard.tsx
+++ b/src/components/ranking/RankingCard.tsx
@@ -38,7 +38,7 @@ export default function RankingCard({
         isPrimary
           ? `border-primary text-primary ${bgWhite ? 'bg-white' : 'bg-secondary'}`
           : 'border-gray-5 bg-white text-text-primary',
-        isLarge ? 'min-h-36 px-16 py-11 ' : 'min-h-26 px-12 py-7',
+        isLarge ? 'min-h-36 px-16 py-11' : 'min-h-26 px-12 py-7',
       ].join(' ')}
     >
       <div

--- a/src/components/ranking/RankingSection.tsx
+++ b/src/components/ranking/RankingSection.tsx
@@ -13,15 +13,17 @@ export default function RankingSection() {
 
   return (
     <div className="flex-1 min-h-0 overflow-auto">
-      <section className="py-8">
-        <div className="h1 mb-4">랭킹을 확인해보세요</div>
-        <div className="p2 mb-2">나의 순위</div>
+      <section className="pt-8">
+        <div className="h1 mb-2">랭킹을 확인해보세요</div>
         {data?.myRankingResponse && (
-          <RankingCard
-            {...data.myRankingResponse}
-            variant="primary"
-            size="lg"
-          />
+          <section className="mb-2">
+            <div className="p2 mb-2">나의 순위</div>
+            <RankingCard
+              {...data.myRankingResponse}
+              variant="primary"
+              size="lg"
+            />
+          </section>
         )}
       </section>
       <div className="flex flex-col">

--- a/src/constants/interviewPlanEmptyRows.ts
+++ b/src/constants/interviewPlanEmptyRows.ts
@@ -9,25 +9,25 @@ export const EMPTY_INTERVIEW_PLAN_ROWS: readonly EmptyInterviewPlanRowConfig[] =
     {
       menuKey: 'empty-0',
       className:
-        'flex h-14 items-center justify-between rounded-lg border border-gray-5 bg-white px-5 py-4 gap-3',
+        'flex h-14 items-center justify-between rounded-lg border border-primary bg-white px-5 py-4 gap-3',
       leading: 'prompt',
     },
     {
       menuKey: 'empty-1',
       className:
-        'flex h-14 items-center justify-end rounded-lg border border-gray-5 bg-white px-5 py-3',
+        'flex h-14 items-center justify-end rounded-lg bg-white px-5 py-3',
       leading: null,
     },
     {
       menuKey: 'empty-2',
       className:
-        'flex h-14 items-center justify-end rounded-lg border border-gray-5 bg-white px-5 py-3',
+        'flex h-14 items-center justify-end rounded-lg bg-white px-5 py-3',
       leading: null,
     },
     {
       menuKey: 'empty-3',
       className:
-        'flex h-9 items-center justify-end rounded-t-lg border border-gray-5 bg-white px-5 py-3',
+        'flex h-9 items-center justify-end rounded-t-lg bg-white px-5 py-3',
       leading: null,
     },
   ]

--- a/src/utils/ellipsizeText.ts
+++ b/src/utils/ellipsizeText.ts
@@ -1,0 +1,10 @@
+export function ellipsizeText(
+  text: string | null | undefined,
+  maxChars: number,
+  suffix = '...',
+  empty = '-',
+): string {
+  const s = text?.trim() ? text : empty
+  if (s.length <= maxChars) return s
+  return `${s.slice(0, maxChars)}${suffix}`
+}

--- a/src/utils/ellipsizeText.ts
+++ b/src/utils/ellipsizeText.ts
@@ -4,7 +4,7 @@ export function ellipsizeText(
   suffix = '...',
   empty = '-',
 ): string {
-  const s = text?.trim() ? text : empty
+  const s = text?.trim() || empty
   if (s.length <= maxChars) return s
-  return `${s.slice(0, maxChars)}${suffix}`
+  return s.slice(0, maxChars) + suffix
 }


### PR DESCRIPTION
## ✨ 작업 내용

> 작업한 내용에 대한 설명을 적어주세요

## 🧩 백그라운드

> 작업이 필요했던 문제 상황을 적어주세요

- 랭킹 화면 퍼블리싱을 보완하였습니다.
- 홈의 면접 일정 영역에서 데이터가 없을 때의 표시 및 스타일을 수정했습니다.
- 긴 문자열은 공통 `ellipsizeText` 유틸로 길이 제한·말줄임 처리하도록 정리했습니다.

## 📸 스크린샷(선택)

> 스크린샷이 필요한 작업이면 스크린샷을 첨부해주세요

<img width="1372" height="711" alt="스크린샷 2026-05-10 오후 4 54 29" src="https://github.com/user-attachments/assets/dbf9aa89-c3bd-41d9-bde4-3c060cb574ac" />

<img width="1119" height="688" alt="스크린샷 2026-05-10 오후 4 56 43" src="https://github.com/user-attachments/assets/c86fe173-0aef-4578-aefd-c3f04959e6cf" />


## ❗️ 관련 이슈
Closes #116 
Closes #117 
Closes #118 

## ✅ 테스트

- [x] 정상 동작 확인

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

> 참고할 사항이 있다면 적어주세요
