### PR TITLE
[fix] 로그인 에러 수정

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -10,7 +10,9 @@ const nextConfig: NextConfig = {
     remotePatterns: [
       { hostname: 'lh3.googleusercontent.com' },
       { hostname: 'k.kakaocdn.net' },
+      { hostname: 'img1.kakaocdn.net' },
       { hostname: 'phinf.pstatic.net' },
+      { hostname: 'ssl.pstatic.net' },
     ],
   },
 }

--- a/src/apis/auth/index.ts
+++ b/src/apis/auth/index.ts
@@ -77,7 +77,13 @@ export const changePassword = async (body: ChangePasswordRequest) => {
   )
   return data.data
 }
-
+export const checkEmail = async (email: string) => {
+  const { data } = await publicClient.get<ApiResponse<string>>(
+    '/users/email-check',
+    { params: { email } },
+  )
+  return data.data
+}
 export const loginWithKakao = () => `${OAUTH_ORIGIN}/oauth2/authorization/kakao`
 
 export const loginWithGoogle = () =>

--- a/src/apis/auth/index.ts
+++ b/src/apis/auth/index.ts
@@ -82,7 +82,7 @@ export const checkEmail = async (email: string) => {
     '/users/email-check',
     { params: { email } },
   )
-  return data.data
+  return data
 }
 export const loginWithKakao = () => `${OAUTH_ORIGIN}/oauth2/authorization/kakao`
 

--- a/src/app/(auth)/forgot-password/page.tsx
+++ b/src/app/(auth)/forgot-password/page.tsx
@@ -2,7 +2,8 @@
 
 import { useState } from 'react'
 import { useMutation } from '@tanstack/react-query'
-import { resetPasswordApi } from '@/apis/auth'
+import { isAxiosError } from 'axios'
+import { checkEmail, resetPasswordApi } from '@/apis/auth'
 import { EMAIL_REGEX } from '@/constants/regex'
 import HelperText from '@/components/common/text/HelperText'
 import Button from '@/components/common/button/Button'
@@ -12,9 +13,14 @@ export default function ForgotPasswordPage() {
   const [email, setEmail] = useState('')
   const [touched, setTouched] = useState(false)
   const [mailSent, setMailSent] = useState(false)
+  const [isCheckingEmail, setIsCheckingEmail] = useState(false)
+
+  const [registeredError, setRegisteredError] = useState(false)
 
   const isValidEmail = EMAIL_REGEX.test(email)
   const showEmailError = touched && email.length > 0 && !isValidEmail
+
+  const fieldError = showEmailError || registeredError
 
   const forgotPasswordMutation = useMutation({
     mutationFn: resetPasswordApi.forgotPassword,
@@ -26,16 +32,41 @@ export default function ForgotPasswordPage() {
     },
   })
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
-    setTouched(true)
 
-    if (!isValidEmail || mailSent || forgotPasswordMutation.isPending) return
-    forgotPasswordMutation.mutate({ email })
+    setTouched(true)
+    setRegisteredError(false)
+
+    if (
+      !isValidEmail ||
+      mailSent ||
+      forgotPasswordMutation.isPending ||
+      isCheckingEmail
+    ) {
+      return
+    }
+
+    setIsCheckingEmail(true)
+    try {
+      await checkEmail(email)
+      setRegisteredError(true)
+    } catch (error) {
+      if (isAxiosError(error) && error.response?.status === 409) {
+        forgotPasswordMutation.mutate({ email })
+      } else {
+        console.error('이메일 확인 실패', error)
+      }
+    } finally {
+      setIsCheckingEmail(false)
+    }
   }
 
   const isButtonDisabled =
-    !isValidEmail || mailSent || forgotPasswordMutation.isPending
+    !isValidEmail ||
+    mailSent ||
+    forgotPasswordMutation.isPending ||
+    isCheckingEmail
 
   return (
     <main className="min-h-screen py-12 flex flex-col justify-center">
@@ -57,13 +88,18 @@ export default function ForgotPasswordPage() {
               onChange={(e) => {
                 setEmail(e.target.value)
                 setTouched(true)
+                setRegisteredError(false)
               }}
               placeholder="이메일을 입력하세요"
-              status={showEmailError ? 'error' : 'default'}
+              status={fieldError ? 'error' : 'default'}
               disabled={mailSent}
             />
-            <HelperText status={showEmailError ? 'error' : 'empty'}>
-              {showEmailError ? '올바른 이메일 주소를 입력해주세요.' : '\u00A0'}
+            <HelperText status={fieldError ? 'error' : 'default'}>
+              {showEmailError
+                ? '올바른 이메일 주소를 입력해주세요.'
+                : registeredError
+                  ? '가입되지 않은 이메일입니다.'
+                  : '\u00A0'}
             </HelperText>
           </div>
 
@@ -73,11 +109,13 @@ export default function ForgotPasswordPage() {
             disabled={isButtonDisabled}
             className="w-full"
           >
-            {forgotPasswordMutation.isPending
-              ? '전송 중...'
-              : mailSent
-                ? '전송 완료'
-                : '메일 전송'}
+            {isCheckingEmail
+              ? '확인 중...'
+              : forgotPasswordMutation.isPending
+                ? '전송 중...'
+                : mailSent
+                  ? '전송 완료'
+                  : '메일 전송'}
           </Button>
         </form>
       </div>

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -103,7 +103,7 @@ export default function Login() {
           </div>
 
           <div className="mb-10 min-h-[22px]">
-            {isLoginError || oauthError === 'email_already_exists' ? (
+            {isLoginError || oauthError ? (
               <HelperText status="error">
                 {oauthError === 'email_already_exists'
                   ? '이미 가입된 이메일입니다.'

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -103,7 +103,7 @@ export default function Login() {
           </div>
 
           <div className="mb-10 min-h-[22px]">
-            {isLoginError || oauthError ? (
+            {isLoginError || oauthError === 'email_already_exists' ? (
               <HelperText status="error">
                 {oauthError === 'email_already_exists'
                   ? '이미 가입된 이메일입니다.'

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react'
 import Image from 'next/image'
 import Link from 'next/link'
-import { useRouter } from 'next/navigation'
+import { useRouter, useSearchParams } from 'next/navigation'
 import { useMutation } from '@tanstack/react-query'
 import { loginApi } from '@/apis/auth'
 import { getHttpStatus } from '@/apis/common/httpError'
@@ -15,9 +15,13 @@ import NaverLogoIcon from '@/assets/icon/naver-logo.svg'
 
 export default function Login() {
   const router = useRouter()
+
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [isLoginError, setIsLoginError] = useState(false)
+
+  const searchParams = useSearchParams()
+  const oauthError = searchParams.get('error')
 
   const loginMutation = useMutation({
     mutationFn: loginApi.login,
@@ -99,9 +103,11 @@ export default function Login() {
           </div>
 
           <div className="mb-10 min-h-[22px]">
-            {isLoginError ? (
+            {isLoginError || oauthError ? (
               <HelperText status="error">
-                아이디 또는 비밀번호가 틀렸습니다.
+                {oauthError === 'email_already_exists'
+                  ? '이미 가입된 이메일입니다.'
+                  : '아이디 또는 비밀번호가 틀렸습니다.'}
               </HelperText>
             ) : (
               '\u00a0'

--- a/src/app/(auth)/oauth2/callback/page.tsx
+++ b/src/app/(auth)/oauth2/callback/page.tsx
@@ -22,7 +22,7 @@ export default function OAuth2CallbackPage() {
   useEffect(() => {
     const error = searchParams.get('error')
     if (error) {
-      router.replace('/login')
+      router.replace(`/login?error=${error}`)
       return
     }
 


### PR DESCRIPTION
## ✨ 작업 내용

> 작업한 내용에 대한 설명을 적어주세요

- 비밀번호 재설정 시 미가입 이메일에 대해 `"가입되지 않은 이메일 입니다."` 에러메세지를 띄우도록 하였습니다.
- 소셜 로그인 `/oauth2/callback?error=email_already_exists` 반환 시 `/login?error=email_already_exists` 로 리다이렉팅하면 인풋 칸 하단에 에러메세지를 반환하도록 로직을 구현하였습니다.

## 🧩 백그라운드

> 작업이 필요했던 문제 상황을 적어주세요

- 미가입 이메일에도 비밀번호 변경 메일이 발송되는 문제가 있었습니다.
- 소셜 로그인 시 이메일 중복 시 안내 없이 로그인 페이지로 리다이렉팅 되는 문제가 있었습니다.


## 📸 스크린샷(선택)

> 스크린샷이 필요한 작업이면 스크린샷을 첨부해주세요

<img width="863" height="857" alt="스크린샷 2026-05-10 오후 7 00 45" src="https://github.com/user-attachments/assets/1268f017-ae0c-4982-b88d-d967575d27c5" />

<img width="859" height="910" alt="스크린샷 2026-05-10 오후 6 58 55" src="https://github.com/user-attachments/assets/48cc84c8-1873-4275-913d-268701d10a14" />

## ❗️ 관련 이슈
Closes #121
Closes #133 

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

> 참고할 사항이 있다면 적어주세요

- 소셜 로그인 리다이렉팅 문제는 테스트할 수 있는 계정이 없어 따로 테스트하지 못했으나 리다이렉팅 되는 경우 에레메세지가 띄워진 화면임은 확인하였습니다.
