### PR TITLE
[11-341] 회원 탈퇴 확인 팝업 구현

### DIFF
--- a/src/apis/job-postings/index.tsx
+++ b/src/apis/job-postings/index.tsx
@@ -62,9 +62,7 @@ export const createJobPostingAnalysisEventSource = (
 
   return fetchEventSource(`${API_BASE_URL}/job-postings/${uuid}/stream`, {
     ...options,
-
     credentials: 'include',
-
     headers: {
       Accept: 'text/event-stream',
       Authorization: `Bearer ${accessToken ?? ''}`,

--- a/src/app/(auth)/forgot-password/page.tsx
+++ b/src/app/(auth)/forgot-password/page.tsx
@@ -107,7 +107,7 @@ export default function ForgotPasswordPage() {
             type="submit"
             variant={isButtonDisabled ? 'secondary' : 'primary'}
             disabled={isButtonDisabled}
-            className="w-full"
+            className="p4 w-full"
           >
             {isCheckingEmail
               ? '확인 중...'

--- a/src/app/(auth)/reset-password/page.tsx
+++ b/src/app/(auth)/reset-password/page.tsx
@@ -24,7 +24,7 @@ function ExpiredLinkFallback() {
             만료된 링크입니다. 비밀번호 재설정을 다시 요청해주세요.
           </p>
           <Link href="/forgot-password">
-            <Button variant="primary" className="w-full">
+            <Button variant="primary" className="p4 w-full">
               재설정 메일 다시 받기
             </Button>
           </Link>
@@ -97,7 +97,7 @@ export default function ResetPasswordPage() {
             type="submit"
             variant={canSubmit ? 'primary' : 'secondary'}
             disabled={!canSubmit}
-            className="w-full"
+            className="p4 w-full"
           >
             {resetMutation.isPending ? '변경 중' : '변경 완료'}
           </Button>

--- a/src/components/auth/signup/EmailSection.tsx
+++ b/src/components/auth/signup/EmailSection.tsx
@@ -179,7 +179,7 @@ export default function EmailSection({ onEmailVerified }: EmailSectionProps) {
             onClick={handleSendCode}
             disabled={sendCodeMutation.isPending || cooldownLeft > 0}
             variant={codeSent ? 'secondary' : 'primary'}
-            className={codeSent ? 'bg-primary-light text-primary' : ''}
+            className={codeSent ? 'p4 bg-primary-light text-primary' : 'p4'}
           >
             {codeSent ? '재전송' : '인증번호'}
           </Button>
@@ -210,6 +210,7 @@ export default function EmailSection({ onEmailVerified }: EmailSectionProps) {
           <Button
             onClick={handleVerifyCode}
             disabled={verifyCodeMutation.isPending || timerExpired || !codeSent}
+            className="p4"
           >
             인증확인
           </Button>

--- a/src/components/auth/signup/NicknameSection.tsx
+++ b/src/components/auth/signup/NicknameSection.tsx
@@ -84,6 +84,7 @@ export default function NicknameSection({
         <Button
           onClick={handleCheckNickname}
           disabled={nicknameMutation.isPending}
+          className="p4"
         >
           중복확인
         </Button>

--- a/src/components/auth/signup/SignUpForm.tsx
+++ b/src/components/auth/signup/SignUpForm.tsx
@@ -79,7 +79,7 @@ export default function SignUpForm() {
         type="submit"
         variant={canSubmit ? 'primary' : 'secondary'}
         disabled={!canSubmit || signupMutation.isPending}
-        className="w-full"
+        className="p4 w-full"
       >
         <span className="h4">회원가입</span>
       </Button>

--- a/src/components/common/button/Button.tsx
+++ b/src/components/common/button/Button.tsx
@@ -21,7 +21,7 @@ export default function Button({
       type="button"
       {...props}
       className={`
-        p4 rounded-lg whitespace-nowrap min-w-22.25 px-4 py-3.5 cursor-pointer
+        rounded-lg whitespace-nowrap min-w-22.25 px-4 py-3.5 cursor-pointer
         disabled:opacity-50 disabled:cursor-not-allowed
         ${variantStyle}
         ${className ?? ''}

--- a/src/components/common/popup/AnalyzingPopup.tsx
+++ b/src/components/common/popup/AnalyzingPopup.tsx
@@ -41,7 +41,7 @@ export default function AnalyzingPopup({
       </div>
       <Button
         variant="outlined"
-        className="w-70 rounded-full! py-3 bg-white hover:bg-secondary"
+        className="p4 w-70 rounded-full! py-3 bg-white hover:bg-secondary"
         onClick={onClose}
       >
         <span className="h3">중단 하기</span>

--- a/src/components/common/popup/CompanyNamePopup.tsx
+++ b/src/components/common/popup/CompanyNamePopup.tsx
@@ -46,7 +46,7 @@ export default function CompanyNamePopup({
       </div>
       <Button
         variant="outlined"
-        className="w-70 rounded-full! py-3 cursor-pointer mt-12 disabled:bg-gray-4 disabled:text-gray-3 disabled:border-gray-4"
+        className="p4 w-70 rounded-full! py-3 cursor-pointer mt-12 disabled:bg-gray-4 disabled:text-gray-3 disabled:border-gray-4"
         disabled={!canSubmit}
         onClick={() => onSubmit(companyName.trim())}
       >

--- a/src/components/common/popup/FailedPopup.tsx
+++ b/src/components/common/popup/FailedPopup.tsx
@@ -28,7 +28,7 @@ export default function FailedPopup({
       <p className="h1 text-primary mb-20">{title}</p>
       <Button
         variant="outlined"
-        className="w-70 rounded-full! py-3 bg-white hover:bg-secondary"
+        className="p4 w-70 rounded-full! py-3 bg-white hover:bg-secondary"
         onClick={onClose}
       >
         <span className="h3">링크 다시 입력하기</span>

--- a/src/components/interview/AnalysisSection.tsx
+++ b/src/components/interview/AnalysisSection.tsx
@@ -153,10 +153,10 @@ export default function AnalysisSection() {
           <p className="h1 text-text-point-red">분석에 실패했어요</p>
           <p className="p1 text-gray-1">연습 이력에서 다시 확인해주세요.</p>
           <Button
-            className="p4 rounded-full! py-3! px-15.5! mt-4.75"
+            className="h3 rounded-full! py-3! px-15.5! mt-4.75"
             onClick={() => router.push('/interview')}
           >
-            <span className="h3 text-white">돌아가기</span>
+            <span className="text-white">돌아가기</span>
           </Button>
         </div>
       </section>

--- a/src/components/interview/AnalysisSection.tsx
+++ b/src/components/interview/AnalysisSection.tsx
@@ -153,7 +153,7 @@ export default function AnalysisSection() {
           <p className="h1 text-text-point-red">분석에 실패했어요</p>
           <p className="p1 text-gray-1">연습 이력에서 다시 확인해주세요.</p>
           <Button
-            className="rounded-full! py-3! px-15.5! mt-4.75"
+            className="p4 rounded-full! py-3! px-15.5! mt-4.75"
             onClick={() => router.push('/interview')}
           >
             <span className="h3 text-white">돌아가기</span>
@@ -189,7 +189,7 @@ export default function AnalysisSection() {
           />
 
           <Button
-            className="rounded-full! py-3! px-18.25! mt-3.5"
+            className="p4 rounded-full! py-3! px-18.25! mt-3.5"
             onClick={() => router.push(`/history/${uuid}`)}
           >
             <span className="h3">리포트 보러가기</span>
@@ -240,7 +240,7 @@ export default function AnalysisSection() {
 
         <Button
           variant="primary"
-          className="rounded-full! py-3! px-15.5! mt-4.75"
+          className="p4 rounded-full! py-3! px-15.5! mt-4.75"
           onClick={() => router.push('/interview')}
         >
           <span className="h3 text-white">다른 면접 진행하기</span>

--- a/src/components/interview/CompleteSection.tsx
+++ b/src/components/interview/CompleteSection.tsx
@@ -47,7 +47,7 @@ export default function CompleteSection({
           </p>
         </div>
         <Button
-          className="rounded-full! py-3! px-16! mt-11"
+          className="p4 rounded-full! py-3! px-16! mt-11"
           onClick={handleNext}
         >
           <span className="h3">

--- a/src/components/interview/CountdownSection.tsx
+++ b/src/components/interview/CountdownSection.tsx
@@ -66,7 +66,7 @@ export default function CountdownSection({
           <p className="h1 text-text-point-red">면접 시작에 실패했어요</p>
           <p className="p1 text-gray-1">잠시 후 다시 시도해주세요.</p>
           <Button
-            className="rounded-full! py-3! px-15.5! mt-4.75"
+            className="p4 rounded-full! py-3! px-15.5! mt-4.75"
             onClick={() => router.push('/interview')}
           >
             <span className="h3">돌아가기</span>

--- a/src/components/interview/JobPostingFormSection.tsx
+++ b/src/components/interview/JobPostingFormSection.tsx
@@ -54,7 +54,7 @@ function CompletePopup({
           <p className="p1 text-gray-2">{subtitle}</p>
         </div>
         <Button
-          className="w-70 rounded-full! py-3 cursor-pointer mt-12"
+          className="p4 w-70 rounded-full! py-3 cursor-pointer mt-12"
           onClick={onAction}
         >
           <span className="h3">{actionLabel}</span>
@@ -117,7 +117,7 @@ export default function JobPostingFormSection() {
 
           <Button
             disabled={!isComplete}
-            className="mx-auto w-101.5 rounded-full! py-3! mt-11.75 disabled:bg-gray-4 disabled:opacity-100"
+            className="p4 mx-auto w-101.5 rounded-full! py-3! mt-11.75 disabled:bg-gray-4 disabled:opacity-100"
             onClick={() => {
               if (!isComplete || createJobPostingMutation.isPending) return
 

--- a/src/components/interview/QuestionSection.tsx
+++ b/src/components/interview/QuestionSection.tsx
@@ -295,7 +295,7 @@ export default function QuestionSection({
               {formatTime(elapsedMs)}
             </span>
             <Button
-              className="w-44.75 rounded-full! py-3!"
+              className="p4 w-44.75 rounded-full! py-3!"
               onClick={handleCompleteAnswer}
               disabled={!question || submitAnswerMutation.isPending}
             >

--- a/src/components/interview/StopConfirmPopup.tsx
+++ b/src/components/interview/StopConfirmPopup.tsx
@@ -17,10 +17,10 @@ export default function StopConfirmPopup({
           <p className="p4">현재 세션은 저장되지 않습니다.</p>
         </div>
         <div className="flex gap-6 w-full">
-          <Button variant="outlined" onClick={onContinue} className="flex-1 h3">
+          <Button variant="outlined" onClick={onContinue} className="p4 flex-1 h3">
             계속하기
           </Button>
-          <Button variant="primary" onClick={onStop} className="flex-1 h3">
+          <Button variant="primary" onClick={onStop} className="p4 flex-1 h3">
             종료
           </Button>
         </div>

--- a/src/components/interview/StopConfirmPopup.tsx
+++ b/src/components/interview/StopConfirmPopup.tsx
@@ -17,10 +17,10 @@ export default function StopConfirmPopup({
           <p className="p4">현재 세션은 저장되지 않습니다.</p>
         </div>
         <div className="flex gap-6 w-full">
-          <Button variant="outlined" onClick={onContinue} className="p4 flex-1 h3">
+          <Button variant="outlined" onClick={onContinue} className="flex-1 h3">
             계속하기
           </Button>
-          <Button variant="primary" onClick={onStop} className="p4 flex-1 h3">
+          <Button variant="primary" onClick={onStop} className="flex-1 h3">
             종료
           </Button>
         </div>

--- a/src/components/setting/SignoutConfirmPopup.tsx
+++ b/src/components/setting/SignoutConfirmPopup.tsx
@@ -1,0 +1,36 @@
+import Button from '@/components/common/button/Button'
+
+interface SignoutConfirmPopupProps {
+  onCancel: () => void
+  onConfirm: () => void
+}
+
+export default function SignoutConfirmPopup({
+  onCancel,
+  onConfirm,
+}: SignoutConfirmPopupProps) {
+  return (
+    <div className="fixed inset-0 bg-black/13 flex items-center justify-center z-50">
+      <div className="bg-white rounded-2xl shadow-[0_0_16px_0_rgba(99,99,99,0.16)] px-10 pt-10 pb-8 flex flex-col gap-8 min-w-100">
+        <div className="flex flex-col items-center gap-4">
+          <h2 className="h3">회원 탈퇴</h2>
+          <p className="p4 text-center">
+            탈퇴 시 계정 정보 및 지금까지의
+            <br />
+            모의면접 분석 결과와 랭킹 정보가 모두 삭제되어
+            <br />
+            복구가 불가합니다. 정말 탈퇴하시겠습니까?
+          </p>
+        </div>
+        <div className="flex gap-4 w-full">
+          <Button variant="primary" onClick={onCancel} className="flex-1 h3">
+            취소하기
+          </Button>
+          <Button variant="outlined" onClick={onConfirm} className="flex-1 h3">
+            탈퇴하기
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/setting/UserInfoSection.tsx
+++ b/src/components/setting/UserInfoSection.tsx
@@ -40,6 +40,7 @@ export default function UserInfoSection() {
   const { mutate: handleSignout } = useMutation({
     mutationFn: signout,
     onSuccess: () => {
+      setIsSignoutPopupOpen(false)
       queryClient.clear()
       router.push('/login')
     },
@@ -191,7 +192,6 @@ export default function UserInfoSection() {
           onCancel={() => setIsSignoutPopupOpen(false)}
           onConfirm={() => {
             handleSignout()
-            setIsSignoutPopupOpen(false)
           }}
         />
       )}

--- a/src/components/setting/UserInfoSection.tsx
+++ b/src/components/setting/UserInfoSection.tsx
@@ -7,6 +7,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import InputBox from '@/components/common/input/InputBox'
 import HelperText from '@/components/common/text/HelperText'
 import ChangePasswordPopup from '@/components/setting/ChangePasswordPopup'
+import SignoutConfirmPopup from '@/components/setting/SignoutConfirmPopup'
 import defaultProfileIcon from '@/assets/icon/default-profile-icon.svg'
 import { useNicknameEdit } from '@/hooks/useNicknameEdit'
 import { getProfile, signout, updateProfile } from '@/apis/user'
@@ -18,6 +19,7 @@ export default function UserInfoSection() {
   const router = useRouter()
   const queryClient = useQueryClient()
   const [isPasswordPopupOpen, setIsPasswordPopupOpen] = useState(false)
+  const [isSignoutPopupOpen, setIsSignoutPopupOpen] = useState(false)
 
   const { data: profile, isLoading } = useQuery({
     queryKey: ['user', 'profile'],
@@ -175,7 +177,7 @@ export default function UserInfoSection() {
         <button
           type="button"
           className="underline"
-          onClick={() => handleSignout()}
+          onClick={() => setIsSignoutPopupOpen(true)}
         >
           회원탈퇴
         </button>
@@ -183,6 +185,15 @@ export default function UserInfoSection() {
 
       {isPasswordPopupOpen && (
         <ChangePasswordPopup onClose={() => setIsPasswordPopupOpen(false)} />
+      )}
+      {isSignoutPopupOpen && (
+        <SignoutConfirmPopup
+          onCancel={() => setIsSignoutPopupOpen(false)}
+          onConfirm={() => {
+            handleSignout()
+            setIsSignoutPopupOpen(false)
+          }}
+        />
       )}
     </div>
   )


### PR DESCRIPTION
## ✨ 작업 내용

> 작업한 내용에 대한 설명을 적어주세요

- 공통 Button 컴포넌트에 기본으로 붙어 있던 텍스트 크기 `h4` 를 제거하고, Button 컴포넌트를 사용하는 곳에서 className으로 타이포그래피를 지정하도록 변경했습니다.
- 버튼 문맥(회원가입, 팝업, 면접 플로우 등)마다 글자 크기·굵기가 다를 수 있어, 공통 버튼은 레이아웃·variant만 담당하고 텍스트 스타일은 화면 단에서 맞추도록 역할을 나눴습니다.
- 회원 탈퇴 확인 팝업을 구현하였습니다.

## 🧩 백그라운드

> 작업이 필요했던 문제 상황을 적어주세요

## 📸 스크린샷(선택)

> 스크린샷이 필요한 작업이면 스크린샷을 첨부해주세요
<img width="1391" height="770" alt="스크린샷 2026-05-15 오전 11 57 45" src="https://github.com/user-attachments/assets/ff663200-7b9c-497d-8226-2b20e2e87ed8" />

## ✅ 테스트

- [x] 정상 동작 확인

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

> 참고할 사항이 있다면 적어주세요
