### PR TITLE
[11-352] 면접 연습 WCAG 개선

### DIFF
--- a/src/components/interview/CompleteSection.tsx
+++ b/src/components/interview/CompleteSection.tsx
@@ -41,7 +41,7 @@ export default function CompleteSection({
           className="object-contain"
         />
         <div className="flex flex-col items-center gap-3.25">
-          <p className="h1">수고하셨습니다</p>
+          <h2 className="h1">수고하셨습니다</h2>
           <p className="p3 text-gray-2">
             {isLast ? '면접이 모두 끝났습니다.' : '다음 질문으로 넘어가주세요.'}
           </p>

--- a/src/components/interview/CountdownSection.tsx
+++ b/src/components/interview/CountdownSection.tsx
@@ -81,6 +81,11 @@ export default function CountdownSection({
       <h1 className="h1 w-full">공고 맞춤 면접 연습</h1>
 
       <div className="flex flex-col items-center justify-center w-full min-w-200 bg-secondary rounded-2xl border border-primary flex-1 min-h-0 gap-6 px-12">
+        <p className="sr-only" aria-live="polite">
+          {question
+            ? `질문 ${questionNumber}: ${question.content}. 잠시 후 답변 화면으로 자동 이동합니다.`
+            : ''}
+        </p>
         <div className="flex flex-col items-center gap-4">
           <span className="bg-primary text-white h4 px-4.25 py-0.75 rounded-full">
             질문 {questionNumber}
@@ -89,7 +94,11 @@ export default function CountdownSection({
         </div>
 
         <div className="relative w-50 h-50">
-          <svg className="w-full h-full rotate-90" viewBox="0 0 120 120">
+          <svg
+            className="w-full h-full rotate-90"
+            viewBox="0 0 120 120"
+            aria-hidden="true"
+          >
             <circle
               cx="60"
               cy="60"
@@ -103,7 +112,12 @@ export default function CountdownSection({
               style={{ transition: 'stroke-dashoffset 1s linear' }}
             />
           </svg>
-          <span className="absolute inset-0 flex items-center justify-center text-[5rem] font-medium text-primary">
+          <span
+            className="absolute inset-0 flex items-center justify-center text-[5rem] font-medium text-primary"
+            aria-live="assertive"
+            aria-atomic="true"
+            aria-label={`${count}초 후 질문 시작`}
+          >
             {count}
           </span>
         </div>

--- a/src/components/interview/CountdownSection.tsx
+++ b/src/components/interview/CountdownSection.tsx
@@ -114,7 +114,7 @@ export default function CountdownSection({
           </svg>
           <span
             className="absolute inset-0 flex items-center justify-center text-[5rem] font-medium text-primary"
-            aria-live="assertive"
+            aria-live="polite"
             aria-atomic="true"
             aria-label={`${count}초 후 질문 시작`}
           >

--- a/src/components/interview/JobPostingFormSection.tsx
+++ b/src/components/interview/JobPostingFormSection.tsx
@@ -89,12 +89,13 @@ export default function JobPostingFormSection() {
       <div className="flex-1 min-h-0 flex flex-col items-center justify-center w-full min-w-200 bg-secondary rounded-2xl border border-primary">
         <div className="flex flex-col gap-8.5 w-115">
           <div className="flex flex-col gap-5">
-            <label className="p3">
+            <label htmlFor="job-posting-url" className="p3">
               <span className="text-primary">채용 공고 링크</span>를
               입력해주세요
             </label>
             <div className="relative">
               <InputBox
+                id="job-posting-url"
                 className="bg-white px-4.75 border-gray-5"
                 value={url}
                 onChange={(e) => setUrl(e.target.value)}

--- a/src/components/interview/QuestionSection.tsx
+++ b/src/components/interview/QuestionSection.tsx
@@ -64,6 +64,7 @@ export default function QuestionSection({
   const [isPaused, setIsPaused] = useState(false)
   const [isStopPopupOpen, setIsStopPopupOpen] = useState(false)
   const wasPausedBeforePopupRef = useRef(false)
+  const [timerAnnouncement, setTimerAnnouncement] = useState('')
 
   const scriptRef = useRef<HTMLDivElement>(null)
 
@@ -85,6 +86,19 @@ export default function QuestionSection({
       scriptRef.current.scrollTop = scriptRef.current.scrollHeight
     }
   }, [transcript, interimTranscript])
+
+  useEffect(() => {
+    const totalSeconds = Math.floor(elapsedMs / 1000)
+    if (totalSeconds > 0 && totalSeconds % 30 === 0) {
+      const minutes = Math.floor(totalSeconds / 60)
+      const seconds = totalSeconds % 60
+      const text =
+        minutes > 0
+          ? `${minutes}분 ${seconds > 0 ? `${seconds}초` : ''}경과`
+          : `${seconds}초 경과`
+      setTimerAnnouncement(text)
+    }
+  }, [elapsedMs])
 
   const {
     volumeBars,
@@ -301,6 +315,9 @@ export default function QuestionSection({
               aria-hidden="true"
             >
               {formatTime(elapsedMs)}
+            </span>
+            <span className="sr-only" aria-live="polite" aria-atomic="true">
+              {timerAnnouncement}
             </span>
             <Button
               className="p4 w-44.75 rounded-full! py-3!"

--- a/src/components/interview/QuestionSection.tsx
+++ b/src/components/interview/QuestionSection.tsx
@@ -221,7 +221,14 @@ export default function QuestionSection({
         <div className="flex flex-col w-full min-w-200 bg-white rounded-2xl border border-primary px-9.5 pt-6 pb-10 flex-1 min-h-0 gap-4">
           {/* 상단 진행 바 + 아이콘 */}
           <div className="flex items-center gap-1 shrink-0">
-            <div className="flex items-center flex-1">
+            <div
+              className="flex items-center flex-1"
+              role="progressbar"
+              aria-valuenow={questionNumber}
+              aria-valuemin={1}
+              aria-valuemax={TOTAL_QUESTIONS}
+              aria-label={`질문 ${questionNumber} / ${TOTAL_QUESTIONS}`}
+            >
               {Array.from({ length: TOTAL_QUESTIONS + 1 }, (_, i) => (
                 <Fragment key={i}>
                   <div
@@ -260,18 +267,18 @@ export default function QuestionSection({
               type="button"
               onClick={handleOpenStopPopup}
               className="relative group cursor-pointer w-6 h-6 shrink-0"
-              aria-label="닫기"
+              aria-label="면접 중단"
             >
               <Image
                 src={quitIcon}
-                alt="닫기"
+                alt="면접 중단"
                 width={24}
                 height={24}
                 className="group-hover:opacity-0 transition-opacity"
               />
               <Image
                 src={quitColorIcon}
-                alt="닫기"
+                alt="면접 중단"
                 width={24}
                 height={24}
                 className="absolute inset-0 opacity-0 group-hover:opacity-100 transition-opacity"
@@ -291,6 +298,7 @@ export default function QuestionSection({
           <div className="flex-1 flex flex-col items-center justify-center gap-4">
             <span
               className={`text-[5rem] font-semibold tabular-nums tracking-tight ${isOverTime ? 'text-text-point-red' : 'text-primary'}`}
+              aria-hidden="true"
             >
               {formatTime(elapsedMs)}
             </span>


### PR DESCRIPTION
## ✨ 작업 내용

> 작업한 내용에 대한 설명을 적어주세요
- CountdownSection
    - 원형 그래프 스크린리더 무시(대신 스크린리더에서 매초 카운트 알림)
    - 질문 로드 시 질문과 잠시후 자동 이동 예고 알림
- QuestionSection
    - 진행률바 role, aria-label 추가 (스크린리더 대응)
    - 타이머 aria-hidden
- CompleteSection
    - `<p className="h1">` -> `<h2 className="h1">` 변경
- JobPostingFormSection
    - `label`과 `inputbox` -> `htmlFor`,`id` 연결

## 🧩 백그라운드

> 작업이 필요했던 문제 상황을 적어주세요

## 📸 스크린샷(선택)

> 스크린샷이 필요한 작업이면 스크린샷을 첨부해주세요

## ✅ 테스트

- [x] 정상 동작 확인

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

> 참고할 사항이 있다면 적어주세요
