### PR TITLE
[refactor] 홈 화면 UI 및 랜더링 개선

### DIFF
--- a/src/apis/schedules/index.tsx
+++ b/src/apis/schedules/index.tsx
@@ -4,6 +4,7 @@ import type {
   ScheduleDetail,
   CreateScheduleRequest,
   UpdateScheduleRequest,
+  GetScheduleListParams,
   GetScheduleListResponse,
   GetScheduleJobPostingsResponse,
 } from '@/apis/schedules/type'
@@ -16,14 +17,17 @@ export const createInterviewSchedule = async (body: CreateScheduleRequest) => {
   return data.data
 }
 
-export const getInterviewScheduleList =
-  async (): Promise<GetScheduleListResponse> => {
-    const { data } =
-      await privateClient.get<ApiResponse<GetScheduleListResponse>>(
-        '/schedules',
-      )
-    return data.data
-  }
+export const getInterviewScheduleList = async (
+  params?: GetScheduleListParams,
+): Promise<GetScheduleListResponse> => {
+  const { data } = await privateClient.get<ApiResponse<GetScheduleListResponse>>(
+    '/schedules',
+    {
+      params: params?.from ? { from: params.from } : undefined,
+    },
+  )
+  return data.data
+}
 
 export const getInterviewSchedule = async (scheduleUuid: string) => {
   const { data } = await privateClient.get<ApiResponse<ScheduleDetail>>(

--- a/src/apis/schedules/type.d.ts
+++ b/src/apis/schedules/type.d.ts
@@ -25,6 +25,10 @@ export interface UpdateScheduleRequest {
   interviewDate: string
 }
 
+export type GetScheduleListParams = {
+  from?: string
+}
+
 export type GetScheduleListResponse = Schedule[]
 
 export interface ScheduleJobPosting {

--- a/src/app/(auth)/forgot-password/page.tsx
+++ b/src/app/(auth)/forgot-password/page.tsx
@@ -81,7 +81,7 @@ export default function ForgotPasswordPage() {
         </div>
 
         <form onSubmit={handleSubmit} className="flex flex-col gap-45">
-          <div className="flex flex-col gap-2">
+          <div className="flex flex-col">
             <InputBox
               type="email"
               value={email}

--- a/src/app/(main)/home/page.tsx
+++ b/src/app/(main)/home/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next'
 import HomeGreetingClient from '@/components/home/hero/HomeGreetingClient'
-import HeroGoalSection from '@/components/home/hero/HeroGoalSection'
+import HeroGoalClient from '@/components/home/hero/HeroGoalClient'
 import InterviewPlanSection from '@/components/home/interviewPlan/InterviewPlanSection'
 import TodayScheduleSection from '@/components/home/todaySchedule/TodayScheduleSection'
 import { homeMockData } from '@/mocks/homeMockData'
@@ -19,7 +19,7 @@ export default function Home() {
 
       <section className="flex flex-1 gap-[clamp(10px,14px,18px)] min-h-0">
         <div className="flex-2 min-h-0 flex">
-          <HeroGoalSection data={data.heroGoal} />
+          <HeroGoalClient />
         </div>
         <div className="flex-1 min-h-0 flex">
           <TodayScheduleSection />

--- a/src/components/auth/signup/EmailSection.tsx
+++ b/src/components/auth/signup/EmailSection.tsx
@@ -159,7 +159,7 @@ export default function EmailSection({ onEmailVerified }: EmailSectionProps) {
       <label className="p4 mb-1.75" htmlFor="email">
         이메일
       </label>
-      <div className="flex flex-col gap-2">
+      <div className="flex flex-col">
         <div className="flex gap-2.75">
           <InputBox
             id="email"
@@ -190,7 +190,7 @@ export default function EmailSection({ onEmailVerified }: EmailSectionProps) {
             : emailHelper.text}
         </HelperText>
       </div>
-      <div className="flex flex-col gap-2">
+      <div className="flex flex-col">
         <div className="flex gap-2.75">
           <InputBox
             type="text"

--- a/src/components/auth/signup/NicknameSection.tsx
+++ b/src/components/auth/signup/NicknameSection.tsx
@@ -61,7 +61,7 @@ export default function NicknameSection({
   }
 
   return (
-    <div className="flex flex-col gap-2">
+    <div className="flex flex-col">
       <label className="p4 mb-1.75" htmlFor="nickname">
         닉네임
       </label>

--- a/src/components/common/input/PasswordField.tsx
+++ b/src/components/common/input/PasswordField.tsx
@@ -33,7 +33,7 @@ export default function PasswordField({
   const [show, setShow] = useState(false)
 
   return (
-    <div className="flex flex-col gap-2">
+    <div className="flex flex-col">
       <label className="p4 mb-1.75" htmlFor={name}>
         {label}
       </label>

--- a/src/components/home/hero/HeroGoalClient.tsx
+++ b/src/components/home/hero/HeroGoalClient.tsx
@@ -1,0 +1,17 @@
+'use client'
+
+import { useQuery } from '@tanstack/react-query'
+import { getJobPostingList } from '@/apis/job-postings'
+import HeroGoalSection from '@/components/home/hero/HeroGoalSection'
+
+export default function HeroGoalClient() {
+  const { data: jobPostings = [] } = useQuery({
+    queryKey: ['job-postings'],
+    queryFn: getJobPostingList,
+    retry: false,
+  })
+
+  const isEmpty = jobPostings.length === 0
+
+  return <HeroGoalSection isEmpty={isEmpty} />
+}

--- a/src/components/home/hero/HeroGoalSection.tsx
+++ b/src/components/home/hero/HeroGoalSection.tsx
@@ -44,13 +44,17 @@ export default function HeroGoalSection({ isEmpty }: HeroGoalSectionProps) {
         지금 시작하기
       </button>
 
-      <div className="absolute right-8 bottom-8 flex items-end pointer-events-none">
-        <Image src={NoteImage} alt="" className="w-[clamp(56px,8vw,120px)]" />
+      <div className="absolute right-10 bottom-12 flex items-end pointer-events-none">
+        <Image
+          src={NoteImage}
+          alt=""
+          className="translate-x-10 w-[clamp(56px,10vw,120px)]"
+        />
 
         <Image
           src={UUGCharacterImage}
           alt="면접 준비 캐릭터"
-          className="translate-y-8 translate-x-2 w-[clamp(240px,25vw,290px)]"
+          className="translate-y-12 w-[clamp(240px,25vw,310px)]"
           priority
         />
       </div>

--- a/src/components/home/hero/HeroGoalSection.tsx
+++ b/src/components/home/hero/HeroGoalSection.tsx
@@ -5,24 +5,20 @@ import { useRouter } from 'next/navigation'
 import UUGCharacterImage from '@/assets/image/uug-character-img.png'
 import NoteImage from '@/assets/image/note-img.png'
 
-type HeroGoalData = {
-  title: string
-  description: string
-  dDayLabel?: string
-  ctaLabel: string
-} | null
+type HeroGoalSectionProps = {
+  isEmpty: boolean
+}
 
-export default function HeroGoalSection({ data }: { data: HeroGoalData }) {
+export default function HeroGoalSection({ isEmpty }: HeroGoalSectionProps) {
   const router = useRouter()
-  const isEmpty = !data
 
   return (
     <div className="relative h-full w-full overflow-hidden rounded-2xl bg-secondary p-6 min-h-0">
       <div>
         {isEmpty ? (
           <>
-            <h2 className="mb-3 h2 text-text-primary">
-              아직 목표 기업을 설정하지 않았어요. 첫 면접 준비를 시작해 볼까요?
+            <h2 className="mb-1 h2 text-text-primary">
+              첫 면접 준비를 시작해볼까요?
             </h2>
             <p className="p3 text-gray-3">
               목표하는 기업의 공고 링크를 준비해주세요
@@ -30,16 +26,12 @@ export default function HeroGoalSection({ data }: { data: HeroGoalData }) {
           </>
         ) : (
           <>
-            <div className="mb-3 flex items-center gap-3">
-              {data.dDayLabel && (
-                <span className="border border-primary p2 rounded-full px-3 bg-white text-primary">
-                  {data.dDayLabel}
-                </span>
-              )}
-              <h2 className="h2 text-text-primary">{data.title}</h2>
-            </div>
-
-            <p className="p3 text-gray-3">{data.description}</p>
+            <h2 className="mb-1 h2 text-text-primary">
+              꾸준한 모의면접으로 합격의 자신감을 채워보세요
+            </h2>
+            <p className="p3 text-gray-3">
+              핵심 직무질문 5개 포함 15분 실전 모의면접에 바로 도전하세요
+            </p>
           </>
         )}
       </div>
@@ -49,7 +41,7 @@ export default function HeroGoalSection({ data }: { data: HeroGoalData }) {
         onClick={() => router.push('/interview')}
         className="absolute left-10 bottom-6 z-10 h4 h-[clamp(40px,5.5vh,56px)] px-[clamp(20px,3vw,48px)] rounded-full bg-primary text-white whitespace-nowrap"
       >
-        {isEmpty ? '지금 시작하기' : data.ctaLabel}
+        지금 시작하기
       </button>
 
       <div className="absolute right-8 bottom-8 flex items-end pointer-events-none">

--- a/src/components/home/hero/HeroGoalSection.tsx
+++ b/src/components/home/hero/HeroGoalSection.tsx
@@ -54,7 +54,7 @@ export default function HeroGoalSection({ isEmpty }: HeroGoalSectionProps) {
         <Image
           src={UUGCharacterImage}
           alt="면접 준비 캐릭터"
-          className="translate-y-12 w-[clamp(240px,25vw,310px)]"
+          className="translate-y-12 w-[clamp(240px,25vw,290px)]"
           priority
         />
       </div>

--- a/src/components/home/hero/HomeGreetingClient.tsx
+++ b/src/components/home/hero/HomeGreetingClient.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useQuery } from '@tanstack/react-query'
+import { getJobPostingList } from '@/apis/job-postings'
 import { getProfile } from '@/apis/user'
 
 type HomeGreetingClientProps = {
@@ -16,11 +17,20 @@ export default function HomeGreetingClient({
     retry: false,
   })
 
+  const { data: jobPostings = [] } = useQuery({
+    queryKey: ['job-postings'],
+    queryFn: getJobPostingList,
+    retry: false,
+  })
+
   const userNickname = profile?.nickname ?? fallbackName
+
+  const isEmpty = jobPostings.length === 0
+  const greetingMessage = isEmpty ? '만나서 반가워요' : '오늘도 연습해볼까요?'
 
   return (
     <h1 className="mb-[clamp(6px,1vw,16px)] h1 text-text-primary">
-      {userNickname}님, 오늘도 연습해볼까요?
+      {userNickname}님, {greetingMessage}
     </h1>
   )
 }

--- a/src/components/home/interviewPlan/InterviewPlanCurriculumColumn.tsx
+++ b/src/components/home/interviewPlan/InterviewPlanCurriculumColumn.tsx
@@ -30,38 +30,40 @@ export default function InterviewPlanCurriculumColumn({
           </div>
         </div>
       ) : (
-        <div className="max-h-[230px] flex-1 rounded-lg border border-primary bg-white px-6.5 py-6.5">
-          <div className="space-y-3">
-            {curriculums.slice(0, 5).map((item) => (
-              <div key={item.uuid} className="flex items-start gap-4">
-                <span
-                  className={[
-                    'mt-2 inline-block h-1.5 w-1.5 rounded-full',
-                    item.isPast ? 'bg-[#C0AFFF]' : 'bg-[#977AFF]',
-                  ].join(' ')}
-                />
-
-                <div className="flex min-w-0 flex-1 items-center justify-between gap-4">
+        <div className="py-6 max-h-[230px] min-h-0 flex-1 overflow-hidden rounded-lg border border-primary bg-white">
+          <div className="h-full overflow-y-auto px-7">
+            <div className="space-y-3">
+              {curriculums.map((item) => (
+                <div key={item.uuid} className="flex items-start gap-4">
                   <span
                     className={[
-                      'p3',
-                      item.isPast ? 'text-gray-4' : 'text-text-primary',
+                      'mt-2 inline-block h-1.5 w-1.5 rounded-full',
+                      item.isPast ? 'bg-[#C0AFFF]' : 'bg-[#977AFF]',
                     ].join(' ')}
-                  >
-                    {item.content}
-                  </span>
+                  />
 
-                  <span
-                    className={[
-                      'shrink-0 p4',
-                      item.isPast ? 'text-gray-4' : 'text-gray-3',
-                    ].join(' ')}
-                  >
-                    {formatMonthDay(item.scheduledDate)}
-                  </span>
+                  <div className="flex min-w-0 flex-1 items-center justify-between gap-4">
+                    <span
+                      className={[
+                        'p3',
+                        item.isPast ? 'text-gray-4' : 'text-text-primary',
+                      ].join(' ')}
+                    >
+                      {item.content}
+                    </span>
+
+                    <span
+                      className={[
+                        'shrink-0 p4',
+                        item.isPast ? 'text-gray-4' : 'text-gray-3',
+                      ].join(' ')}
+                    >
+                      {formatMonthDay(item.scheduledDate)}
+                    </span>
+                  </div>
                 </div>
-              </div>
-            ))}
+              ))}
+            </div>
           </div>
         </div>
       )}

--- a/src/components/home/interviewPlan/InterviewPlanScheduleColumn.tsx
+++ b/src/components/home/interviewPlan/InterviewPlanScheduleColumn.tsx
@@ -2,10 +2,12 @@
 
 import { IconPlus } from '@tabler/icons-react'
 import { useQuery } from '@tanstack/react-query'
-import { formatMonthDay, getDDay } from '@/utils/date'
+import { formatFullDate, formatMonthDay, getDDay } from '@/utils/date'
 import { getInterviewScheduleList } from '@/apis/schedules'
 import InterviewPlanDotsTrigger from '@/components/home/interviewPlan/InterviewPlanDotsTrigger'
 import { EMPTY_INTERVIEW_PLAN_ROWS } from '@/constants/interviewPlanEmptyRows'
+
+const scheduleListFrom = formatFullDate(new Date())
 
 type InterviewPlanScheduleColumnProps = {
   selectedScheduleUuid: string | null
@@ -21,8 +23,8 @@ export default function InterviewPlanScheduleColumn({
   onSelectSchedule,
 }: InterviewPlanScheduleColumnProps) {
   const { data: schedules, isLoading } = useQuery({
-    queryKey: ['schedules'],
-    queryFn: getInterviewScheduleList,
+    queryKey: ['schedules', scheduleListFrom],
+    queryFn: () => getInterviewScheduleList({ from: scheduleListFrom }),
   })
 
   const scheduleList = schedules ?? []

--- a/src/components/home/interviewPlan/InterviewPlanSection.tsx
+++ b/src/components/home/interviewPlan/InterviewPlanSection.tsx
@@ -14,6 +14,9 @@ import InterviewPlanScheduleColumn from '@/components/home/interviewPlan/Intervi
 import InterviewScheduleRegisterPopup, {
   type InterviewSchedulePopupMode,
 } from '@/components/home/interviewPlan/InterviewScheduleRegisterPopup'
+import { formatFullDate } from '@/utils/date'
+
+const scheduleListFrom = formatFullDate(new Date())
 
 export default function InterviewPlanSection() {
   const [selectedScheduleUuid, setSelectedScheduleUuid] = useState<
@@ -42,8 +45,8 @@ export default function InterviewPlanSection() {
     })
 
   const { data: schedules, isSuccess: isSchedulesSuccess } = useQuery({
-    queryKey: ['schedules'],
-    queryFn: getInterviewScheduleList,
+    queryKey: ['schedules', scheduleListFrom],
+    queryFn: () => getInterviewScheduleList({ from: scheduleListFrom }),
   })
 
   const deleteInterviewScheduleMutation = useMutation({

--- a/src/components/home/todaySchedule/TodayScheduleSection.tsx
+++ b/src/components/home/todaySchedule/TodayScheduleSection.tsx
@@ -4,6 +4,7 @@ import { IconChevronRight, IconChevronLeft } from '@tabler/icons-react'
 import { useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { getCurriculumsByDate } from '@/apis/curriculum'
+import { getInterviewScheduleList } from '@/apis/schedules'
 import { formatFullDate } from '@/utils/date'
 import { getWeekDates } from '@/utils/getWeekDates'
 import { ellipsizeText } from '@/utils/ellipsizeText'
@@ -38,14 +39,25 @@ export default function TodayScheduleSection() {
     setSelectedDate(hasToday ? today : nextWeekDates[0].fullDate)
   }
 
-  const { data: curriculumData, isLoading } = useQuery({
+  const { data: curriculumData, isLoading: isCurriculumLoading } = useQuery({
     queryKey: ['curriculumsByDate', selectedDate],
     queryFn: () => getCurriculumsByDate(selectedDate),
     enabled: Boolean(selectedDate),
   })
 
+  const { data: schedules = [], isLoading: isSchedulesLoading } = useQuery({
+    queryKey: ['schedules'],
+    queryFn: () => getInterviewScheduleList(),
+    retry: false,
+  })
+
   const curriculumList = curriculumData ?? []
-  const isEmpty = !isLoading && curriculumList.length === 0
+  const isEmpty = !isCurriculumLoading && curriculumList.length === 0
+
+  const hasRegisteredSchedules = !isSchedulesLoading && schedules.length > 0
+  const emptyMessage = hasRegisteredSchedules
+    ? '등록된 면접 일정이 없습니다'
+    : '일정에 맞게 오늘의 스케줄을 생성해요'
 
   return (
     <div className="h-full w-full min-h-0 overflow-hidden rounded-2xl bg-secondary">
@@ -89,7 +101,7 @@ export default function TodayScheduleSection() {
           {isEmpty ? (
             <div className="space-y-3 overflow-hidden">
               <div className="p3 w-full rounded-lg border border-primary bg-white px-5 py-4 text-left text-gray-3 ">
-                일정에 맞게 오늘의 스케줄을 생성해요
+                {emptyMessage}
               </div>
               <div className="h-14 rounded-lg bg-white" />
               <div className="h-14 rounded-lg bg-white" />

--- a/src/components/interview/JobPostingFormSection.tsx
+++ b/src/components/interview/JobPostingFormSection.tsx
@@ -103,7 +103,7 @@ export default function JobPostingFormSection() {
                 placeholder="원티드, 잡코리아 사이트의 채용공고만 가능합니다."
                 focusPrimary
               />
-              <div className="absolute left-0 top-full pt-1">
+              <div className="absolute left-0 top-full">
                 <HelperText
                   status={urlError ? 'error' : urlValid ? 'success' : 'empty'}
                 >

--- a/src/components/setting/UserInfoSection.tsx
+++ b/src/components/setting/UserInfoSection.tsx
@@ -238,8 +238,8 @@ export default function UserInfoSection() {
           />
         </div>
         <div />
-        <div className="flex flex-col gap-2">
-          <label className="p4 text-gray-2">닉네임</label>
+        <div className="flex flex-col">
+          <label className="p4 mb-2 text-gray-2">닉네임</label>
           <div className="flex flex-row gap-3">
             <InputBox
               className={`border-gray-5 ${isEditingNickname ? 'text-text-primary' : 'text-gray-4'}`}


### PR DESCRIPTION
## ✨ 작업 내용

> 작업한 내용에 대한 설명을 적어주세요

- 홈 화면 히어로·인사 문구를 `GET /job-postings` response data 유무 `isEmpty`에 따라 분기
    - 등록된 공고 없음: 인사 {닉네임}님, 만나서 반가워요 / 히어로 첫 면접 준비를 시작해볼까요?
    - 등록된 공고 있음: 인사 {닉네임}님, 오늘도 연습해볼까요? / 히어로 꾸준한 모의면접으로 합격의 자신감을 채워보세요
- mock heroGoal 데이터 의존 제거 → HeroGoalClient에서 API 조회 후 HeroGoalSection에 `isEmpty` 전달
- 면접 일정 목록 API에 from `YYYY-MM-DD` query parameter 지원 및 홈 면접 일정 조회 시 오늘 날짜 기준으로 요청
- 면접 커리큘럼 목록 5개 제한 제거, max-h-[230px] 영역 내 세로 스크롤 적용
- 히어로 섹션 캐릭터와 노트 이미지 위치 및 간격 조정

## 🧩 백그라운드

> 작업이 필요했던 문제 상황을 적어주세요

- 홈 히어로 문구가 mock 데이터 기반이라 실제 사용자 상태(채용 공고 등록 여부)와 맞지 않았음
- 신규/기존 사용자에 따라 다른 온보딩·재방문 메시지를 보여줄 필요가 있었음
- 면접 일정에 대한 커리큘럼이 5개만 보이는 제한이 있어 스크롤 및 전체 목록 표시가 필요했음
- 면접 일정 API가 from 날짜 필터를 지원하므로, 오늘 이후 일정만 조회하도록 연동

## 📸 스크린샷(선택)

> 스크린샷이 필요한 작업이면 스크린샷을 첨부해주세요

## ✅ 테스트

- [x] 정상 동작 확인

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

> 참고할 사항이 있다면 적어주세요
