### PR TITLE
[fix] 프로필 이미지 원형 크롭 적용

### DIFF
--- a/src/components/common/ProfileImage.tsx
+++ b/src/components/common/ProfileImage.tsx
@@ -26,7 +26,8 @@ export default function ProfileImage({
       alt={alt}
       width={width}
       height={height}
-      className={className}
+      style={{ width, height }}
+      className={`shrink-0 rounded-full object-cover ${className ?? ''}`}
       unoptimized={isRemoteImage}
     />
   )

--- a/src/components/common/header/Header.tsx
+++ b/src/components/common/header/Header.tsx
@@ -118,7 +118,7 @@ export default function Header({ className = '' }: HeaderProps) {
                   alt="프로필 이미지"
                   width={30}
                   height={30}
-                  className="rounded-full mr-3.25"
+                  className="mr-3.25"
                 />
                 <span className="p1 mr-3.75">{profile?.nickname} 님</span>
               </>

--- a/src/components/ranking/RankingCard.tsx
+++ b/src/components/ranking/RankingCard.tsx
@@ -1,6 +1,5 @@
-import Image from 'next/image'
-import { /* IconSchoolFilled, */ IconFileTextFilled } from '@tabler/icons-react'
-import defaultProfileIcon from '@/assets/icon/default-profile-icon.svg'
+import { IconFileTextFilled } from '@tabler/icons-react'
+import ProfileImage from '@/components/common/ProfileImage'
 
 type RankingCardVariant = 'primary' | 'secondary'
 type RankingCardSize = 'md' | 'lg'
@@ -50,12 +49,11 @@ export default function RankingCard({
           #{rank}
         </span>
 
-        <Image
-          src={profileImageUrl || defaultProfileIcon}
+        <ProfileImage
+          profileImageUrl={profileImageUrl}
           alt={`${nickname} 프로필`}
           width={64}
           height={64}
-          className="rounded-full object-cover shrink-0"
         />
 
         <div>

--- a/src/components/setting/UserInfoSection.tsx
+++ b/src/components/setting/UserInfoSection.tsx
@@ -180,7 +180,6 @@ export default function UserInfoSection() {
             alt="프로필 사진"
             width={64}
             height={64}
-            className="h-16 w-16 rounded-full object-cover"
           />
           <button
             type="button"


### PR DESCRIPTION
## ✨ 작업 내용

> 작업한 내용에 대한 설명을 적어주세요

- `ProfileImage.tsx`에 `rounded-full, object-cover`를 공통 적용
- `RankingCard.tsx`에서 next/image 직접 사용 → ProfileImage로 교체
- `Header.tsx`, `UserInfoSection.tsx`에서 중복 스타일(rounded-full, object-cover 등) 제거

## 🧩 백그라운드

> 작업이 필요했던 문제 상황을 적어주세요

<img width="375" height="135" alt="스크린샷 2026-05-28 오전 10 52 17" src="https://github.com/user-attachments/assets/f5cd6339-300e-426e-853c-bc8e3fdfea4a" />

- 세로로 긴 프로필 이미지가 원형 영역에서 늘어나 보이는 문제가 있었습니다.
- 헤더·환경 설정은 ProfileImage를 쓰고 있었지만, 공통 컴포넌트에 object-cover가 없어 화면마다 스타일이 달랐습니다.

## 📸 스크린샷(선택)

> 스크린샷이 필요한 작업이면 스크린샷을 첨부해주세요

## ✅ 테스트

- [x] 정상 동작 확인

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

> 참고할 사항이 있다면 적어주세요
