### PR TITLE
[refactor] 설정 페이지 Resource Load Delay 개선

### DIFF
--- a/src/apis/user/queries.ts
+++ b/src/apis/user/queries.ts
@@ -1,0 +1,13 @@
+import { queryOptions } from '@tanstack/react-query'
+import { getProfile } from './index'
+
+export const PROFILE_QUERY_KEY = ['user', 'profile'] as const
+
+const PROFILE_STALE_TIME_MS = 5 * 60 * 1000
+
+export const profileQueryOptions = queryOptions({
+  queryKey: PROFILE_QUERY_KEY,
+  queryFn: getProfile,
+  staleTime: PROFILE_STALE_TIME_MS,
+  retry: false,
+})

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -2,13 +2,7 @@
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 
-const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      staleTime: 5 * 60 * 1000,
-    },
-  },
-})
+const queryClient = new QueryClient()
 
 export default function Providers({ children }: { children: React.ReactNode }) {
   return (

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -2,7 +2,13 @@
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 
-const queryClient = new QueryClient()
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 5 * 60 * 1000,
+    },
+  },
+})
 
 export default function Providers({ children }: { children: React.ReactNode }) {
   return (

--- a/src/components/common/header/Header.tsx
+++ b/src/components/common/header/Header.tsx
@@ -16,7 +16,7 @@ import {
   hasSessionMarker,
   clearAuthTokens,
 } from '@/utils/tokenStorage'
-import { getProfile } from '@/apis/user'
+import { PROFILE_QUERY_KEY, profileQueryOptions } from '@/apis/user/queries'
 import { logout } from '@/apis/auth'
 
 interface HeaderProps {
@@ -41,10 +41,8 @@ export default function Header({ className = '' }: HeaderProps) {
   }, [])
 
   const { data: profile, isLoading: isProfileLoading } = useQuery({
-    queryKey: ['user', 'profile'],
-    queryFn: getProfile,
+    ...profileQueryOptions,
     enabled: queryEnabled === true,
-    retry: false,
   })
 
   useEffect(() => {
@@ -64,7 +62,7 @@ export default function Header({ className = '' }: HeaderProps) {
     mutationFn: logout,
     onSettled: () => {
       clearAuthTokens()
-      queryClient.removeQueries({ queryKey: ['user', 'profile'] })
+      queryClient.removeQueries({ queryKey: PROFILE_QUERY_KEY })
       setQueryEnabled(false)
       setOpen(false)
       router.replace('/')

--- a/src/components/home/hero/HomeGreetingClient.tsx
+++ b/src/components/home/hero/HomeGreetingClient.tsx
@@ -2,7 +2,7 @@
 
 import { useQuery } from '@tanstack/react-query'
 import { getJobPostingList } from '@/apis/job-postings'
-import { getProfile } from '@/apis/user'
+import { profileQueryOptions } from '@/apis/user/queries'
 
 type HomeGreetingClientProps = {
   fallbackName: string
@@ -11,11 +11,7 @@ type HomeGreetingClientProps = {
 export default function HomeGreetingClient({
   fallbackName,
 }: HomeGreetingClientProps) {
-  const { data: profile } = useQuery({
-    queryKey: ['user', 'profile'],
-    queryFn: getProfile,
-    retry: false,
-  })
+  const { data: profile } = useQuery(profileQueryOptions)
 
   const { data: jobPostings = [] } = useQuery({
     queryKey: ['job-postings'],

--- a/src/components/setting/UserInfoSection.tsx
+++ b/src/components/setting/UserInfoSection.tsx
@@ -29,6 +29,9 @@ export default function UserInfoSection() {
   const { data: profile, isLoading } = useQuery({
     queryKey: ['user', 'profile'],
     queryFn: getProfile,
+    placeholderData: () =>
+      queryClient.getQueryData<UserProfile>(['user', 'profile']),
+    retry: false,
   })
 
   const { mutate: handleLogout } = useMutation({
@@ -157,7 +160,11 @@ export default function UserInfoSection() {
     })
   }
 
-  if (isLoading || !profile) {
+  if (!profile && isLoading) {
+    return <div className="flex-1" />
+  }
+
+  if (!profile) {
     return <div className="flex-1" />
   }
 

--- a/src/components/setting/UserInfoSection.tsx
+++ b/src/components/setting/UserInfoSection.tsx
@@ -11,7 +11,8 @@ import ChangePasswordPopup from '@/components/setting/ChangePasswordPopup'
 import SignoutConfirmPopup from '@/components/setting/SignoutConfirmPopup'
 import { useNicknameEdit } from '@/hooks/useNicknameEdit'
 import { deleteProfileImage, uploadProfileImage } from '@/apis/profile-image'
-import { getProfile, signout, updateProfile } from '@/apis/user'
+import { signout, updateProfile } from '@/apis/user'
+import { PROFILE_QUERY_KEY, profileQueryOptions } from '@/apis/user/queries'
 import type { UserProfile } from '@/apis/user/type'
 import { logout } from '@/apis/auth'
 import { getHttpStatus } from '@/apis/common/httpError'
@@ -26,13 +27,7 @@ export default function UserInfoSection() {
   const profileImageMenuRef = useRef<HTMLDivElement>(null)
   const profileImageInputRef = useRef<HTMLInputElement>(null)
 
-  const { data: profile, isLoading } = useQuery({
-    queryKey: ['user', 'profile'],
-    queryFn: getProfile,
-    placeholderData: () =>
-      queryClient.getQueryData<UserProfile>(['user', 'profile']),
-    retry: false,
-  })
+  const { data: profile } = useQuery(profileQueryOptions)
 
   const { mutate: handleLogout } = useMutation({
     mutationFn: logout,
@@ -75,7 +70,7 @@ export default function UserInfoSection() {
   } = useMutation({
     mutationFn: uploadProfileImage,
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: ['user', 'profile'] })
+      await queryClient.invalidateQueries({ queryKey: PROFILE_QUERY_KEY })
     },
     onError: (e) => {
       console.log('프로필 이미지 업로드에 실패하였습니다', e) //TODO: 토스트로 변경
@@ -88,20 +83,20 @@ export default function UserInfoSection() {
   } = useMutation({
     mutationFn: deleteProfileImage,
     onMutate: async () => {
-      await queryClient.cancelQueries({ queryKey: ['user', 'profile'] })
-      const previous = queryClient.getQueryData<UserProfile>(['user', 'profile'])
-      queryClient.setQueryData<UserProfile>(['user', 'profile'], (prev) =>
+      await queryClient.cancelQueries({ queryKey: PROFILE_QUERY_KEY })
+      const previous = queryClient.getQueryData<UserProfile>(PROFILE_QUERY_KEY)
+      queryClient.setQueryData<UserProfile>(PROFILE_QUERY_KEY, (prev) =>
         prev ? { ...prev, profileImageUrl: '' } : prev,
       )
       return { previous }
     },
     onSuccess: async () => {
       setIsProfileImageMenuOpen(false)
-      await queryClient.invalidateQueries({ queryKey: ['user', 'profile'] })
+      await queryClient.invalidateQueries({ queryKey: PROFILE_QUERY_KEY })
     },
     onError: (e, _variables, context) => {
       if (context?.previous) {
-        queryClient.setQueryData(['user', 'profile'], context.previous)
+        queryClient.setQueryData(PROFILE_QUERY_KEY, context.previous)
       }
       console.log('프로필 이미지 삭제에 실패하였습니다', e) //TODO: 토스트로 변경
     },
@@ -118,7 +113,7 @@ export default function UserInfoSection() {
         profileImageUrl: profile?.profileImageUrl ?? '',
       }),
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: ['user', 'profile'] })
+      await queryClient.invalidateQueries({ queryKey: PROFILE_QUERY_KEY })
       handleNicknameConfirm()
     },
     onError: (e) => {
@@ -158,10 +153,6 @@ export default function UserInfoSection() {
         }
       },
     })
-  }
-
-  if (!profile && isLoading) {
-    return <div className="flex-1" />
   }
 
   if (!profile) {


### PR DESCRIPTION
## ✨ 작업 내용

> 작업한 내용에 대한 설명을 적어주세요

- 설정 페이지 진입 시 프로필(`/users/me`)을 다시 기다리지 않고 Header 캐시를 재사용하도록 개선했습니다.
- `staleTime` 5분 적용으로 동일 세션 내 불필요한 `/me` 재요청을 줄였습니다.
- 로딩 분기를 `!profile && isLoading`으로 변경하여 캐시가 있으면 API 완료를 기다리지 않고 프로필 및 이미지를 렌더링하도록 변경하였습니다.

## 🧩 백그라운드

> 작업이 필요했던 문제 상황을 적어주세요

- `/setting` 페이지는 `GET /users/me` 응답 후에야 프로필 및 이미지가 표시되어 진입 시 로딩이 지연되는 문제가 있었습니다. 
- Lighthouse 기준 Performance 87점, LCP 2.2s였습니다. 개선 이후 로컬 빌드 환경에서 100점, LCP 0.6s 개선 확인하였습니다.


## 📸 스크린샷(선택)

> 스크린샷이 필요한 작업이면 스크린샷을 첨부해주세요

## ✅ 테스트

- [ ] 정상 동작 확인

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

> 참고할 사항이 있다면 적어주세요
